### PR TITLE
use non-dated reference to RDF 1.1 Semantics

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -110,7 +110,7 @@
 <section id='sotd'>
   <p>This document is part of RDF 1.2 document suite.
     This is a revision of the 2014 Semantics specification for RDF
-    [[RDF11-MT-20140225]] and supersedes that document.
+    [[RDF11-MT]] and supersedes that document.
     For an informal summary of the substantive (non-editorial)
     changes since then,
     see <a href="http://www.w3.org/2011/rdf-wg/wiki/Entailment_Changes">Entailment


### PR DESCRIPTION
Fixes #6


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/8.html" title="Last updated on Feb 8, 2023, 9:18 PM UTC (0400ad9)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/8/602b3e6...0400ad9.html" title="Last updated on Feb 8, 2023, 9:18 PM UTC (0400ad9)">Diff</a>