### PR TITLE
Add IDs to two tables that lack them

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1117,7 +1117,7 @@
   <p> An <dfn>RDFS interpretation</dfn> (<strong>recognizing D</strong>) is an <a>RDF interpretation</a> (recognizing D) I
     which <a>satisfies</a> the semantic conditions in the following table, and all the triples in the subsequent table of RDFS axiomatic triples.</p>
 
-  <table>
+  <table id="rdfs_semantic_conditions">
     <caption>RDFS semantic conditions.</caption>
     <tr>
       <td class="semantictable" id="rdfssemcond1"> <p>ICEXT(y) is defined to be { x : &lt; x,y &gt; is in IEXT(I(<code>rdf:type</code>)) }</p>
@@ -1339,7 +1339,7 @@
       <P>RDFS entailment holds for all the following patterns, 
         which correspond closely to the RDFS semantic conditions:</p>
 
-      <table>
+      <table id="rdfs_entailment_patterns">
         <caption>RDFS entailment patterns.</caption>
         <tbody>
           <tr >


### PR DESCRIPTION
so FragIDs now work for these tables.

(Such IDs should be added to *all* tables that now lack them!)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-semantics/pull/33.html" title="Last updated on May 16, 2023, 2:56 AM UTC (f6eb833)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/33/a72c6f4...TallTed:f6eb833.html" title="Last updated on May 16, 2023, 2:56 AM UTC (f6eb833)">Diff</a>