### PR TITLE
add entailment rule for datatypes

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2061,7 +2061,7 @@
   <h2>Substantive changes since RDF 1.1</h2>
 
   <ul>
-    <li> The RDF entailment rule <a>rdfD1a</a> was added.  This rule was not added for RDF entailment when the two built-in dataypes were added to RDF entailment. </li>
+    <li> RDF entailment rule <a>rdfD1a</a> was added in RDF 1.2.  This rule should have been included in RDF 1.1 when the two built-in datatypes (<code>xsd:string</code> and <code>rdf:langString</code>) were added to RDF entailment. </li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1033,6 +1033,25 @@
       <p><code>ex:a ex:p _:x . <br/>
        _:x rdf:type xsd:integer . </code></p>
 
+      <p>The last semantic condition above also justifies the following entailment pattern:</p>
+
+      <table>
+        <tbody>
+          <tr>
+            <th > </th>
+            <th ><strong>any S</strong></th>
+            <th ><strong>then S RDF entails, recognizing D</strong></th>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfD1a</dfn></td>
+            <td class="othertable">for ddd in D with non-empty value space</td>
+            <td class="othertable">_:nnn <code>rdf:type</code> ddd <code>.</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+
+
       <p>In addition, the first RDF semantic condition justifies the following entailment pattern:</p>
 
       <table>
@@ -1588,7 +1607,7 @@
     <li>Add to S all the RDF (and RDFS) axiomatic triples which do not contain any container membership property IRI.</li>
     <li>For each container membership property IRI which occurs in E, add the RDF (and RDFS) axiomatic triples which contain that IRI.</li>
     <li>If no triples were added in step 2., add the RDF (and RDFS) axiomatic triples which contain <code>rdf:_1</code>.</li>
-    <li>Apply the rules <a>GrdfD1</a> and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a>),
+    <li>Apply the rules <a>GrdfD1</a>, <a>rdfD1a</a>, and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a>),
       with D={<code>rdf:langString</code>, <code>xsd:string</code>}, to the set in all possible ways, to exhaustion.</li>
   </ol>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -2061,7 +2061,7 @@
   <h2>Substantive changes since RDF 1.1</h2>
 
   <ul>
-    <li> None so far. </li>
+    <li> The RDF entailment rule <a>rdfD1a</a> was added.  This rule was not added for RDF entailment when the two built-in dataypes were added to RDF entailment. </li>
   </ul>
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1038,11 +1038,11 @@
       <table>
         <tbody>
           <tr>
-            <th > </th>
-            <th ><strong>any S</strong></th>
-            <th ><strong>then S RDF entails, recognizing D</strong></th>
+            <th> </th>
+            <th><strong>any S</strong></th>
+            <th><strong>then S RDF entails, recognizing D</strong></th>
           </tr>
-          <tr >
+          <tr>
             <td class="othertable"><dfn>rdfD1a</dfn></td>
             <td class="othertable">for ddd in D with non-empty value space</td>
             <td class="othertable">_:nnn <code>rdf:type</code> ddd <code>.</code></td>


### PR DESCRIPTION
Fixes #44

The basic issue is that RDF entailment recognizes the rdf:langString and the xsd:string datatypes.  This means that the domain of discourse includes all XSD strings and all language-tagged strings.   In these interpretations the following triples are true:
```
_:b rdf:type rdf:langString .
_:c rdf:type xsd:string.
```
and thus need to be accounted for in the entailment patterns.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/45.html" title="Last updated on Nov 2, 2023, 4:02 PM UTC (290ffda)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/45/295f6fa...290ffda.html" title="Last updated on Nov 2, 2023, 4:02 PM UTC (290ffda)">Diff</a>