### PR TITLE
New triple term semantics in the rdf-semantics spec

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1,175 +1,137 @@
 <!DOCTYPE html>
-<html lang="en">
-  <head>
-    <meta charset="UTF-8">
-    <title>RDF 1.2 Semantics</title>
-    <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
-    <script src="./common/local-biblio.js" class="remove"></script>
-    <script src="./common/fixup.js" class="remove"></script>
-    <script class='remove'>
-      var respecConfig = {
-        localBiblio:          localBibliography,
-        specStatus:           "ED",
-        edDraftURI:           "https://w3c.github.io/rdf-semantics/spec/",
-        testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf-mt/",
-        shortName:            "rdf12-semantics",
-        copyrightStart:       "2004",
-      
-        previousPublishDate:  "2014-02-25",
-        previousMaturity:     "REC",
-        prevRecShortname:     "rdf11-mt",
-      
-        editors: [
-          { name: "Peter Patel-Schneider", w3cid: "13382"},
-          { name: "Dörthe Arndt", w3cid: "111308"},
-          { name: "Timothée Haudebourg", w3cid: "138654"},
-        ],
-      
-        formerEditors:  [
-          { name: "Patrick J. Hayes" },
-        ],
-      
-        github: "https://github.com/w3c/rdf-semantics/",
-        group:           "rdf-star",
-        doJsonLd:     true,
-        wgPublicList: "public-rdf-star-wg", 
-        xref:   [ "RDF12-CONCEPTS" ],
-      //      localBiblio:          localBibliography,
-      
-        lint: { "no-unused-dfns": false }
-      };
-    </script>
-    <style>
-      .semantictable {
-      background-color: #FFFFAA;
-      padding: 0.5em;
-      border: 1px solid black;
-      }
-      .ruletable {
-      background-color: #DDDDFF;
-      padding: 0.5em;
-      border: 1px solid black;
-      }
-      .othertable {
-      background-color: #FDFDFD;
-      padding: 0.5em;
-      }
-      .tabletitle {
-      font-size: small;
-      font-weight: bolder;
-      }
-      .technote {
-      font-size: small;
+<html>
+<head>
+  <meta http-equiv='Content-Type' content='text/html;charset=utf-8'/>
+  <title>RDF 1.2 Semantics</title>
+  <script src='https://www.w3.org/Tools/respec/respec-w3c' class='remove'></script>
+  <script src="./common/local-biblio.js" class="remove"></script>
+  <script src="./common/fixup.js" class="remove"></script>
+  <script class='remove'>
+    var respecConfig = {
+      localBiblio:          localBibliography,
+      specStatus:           "ED",
+      edDraftURI:           "https://w3c.github.io/rdf-semantics/spec/",
+      testSuiteURI:         "https://w3c.github.io/rdf-tests/rdf-mt/",
+      shortName:            "rdf12-semantics",
+      copyrightStart:       "2004",
+
+      previousPublishDate:  "2014-02-25",
+      previousMaturity:     "REC",
+      prevRecShortname:     "rdf11-mt",
+
+      editors: [
+        { name: "Peter Patel-Schneider", w3cid: "13382"},
+        { name: "Dörthe Arndt", w3cid: "111308"},
+        { name: "Timothée Haudebourg", w3cid: "138654"},
+      ],
+
+      formerEditors:  [
+        { name: "Patrick J. Hayes" },
+      ],
+
+      github: "https://github.com/w3c/rdf-semantics/",
+      group:           "rdf-star",
+      doJsonLd:     true,
+      wgPublicList: "public-rdf-star-wg", 
+      xref:   [ "RDF12-CONCEPTS" ],
+//      localBiblio:          localBibliography,
+
+      lint: { "no-unused-dfns": false }
+    };
+  </script>
+  <style>
+  .semantictable {background-color: #FFFFAA; padding:0.5em;}
+  .ruletable {background-color: #DDDDFF; padding:0.5em;}
+  .othertable {background-color: #FDFDFD; padding:0.5em;}
+  .tabletitle {font-size: small; font-weight: bolder;}
+
+  .technote {
+      font-size:small;
       margin: 2em 0em 0em;
-      padding: 1em;
+      padding:    1em;
       border: 2px solid #cff6d9;
       background: #e2fff0;
-      }
-      .technote::before {
-      content: "Technical Note";
-      display: block;
-      width: 150px;
+  }
+
+  .technote::before {
+      content:    "Technical Note";
+      display:    block;
+      width:  150px;
       margin: -1.5em 0 0.5em 0;
-      font-weight: bold;
+      font-weight:    bold;
       border: 1px solid #cff6d9;
       background: #eff;
-      padding: 3px 1em;
-      }
-      .changenote {
-      font-size: small;
+      padding:    3px 1em;
+  }
+
+
+  .changenote {
+      font-size:small;
       margin: 1em 0em 0em;
-      padding: 1em;
+      padding:    1em;
       border: 2px solid #cff6d9;
       background: #ffddfe;
-      }
-      .changenote::before {
-      content: "Change Note";
-      display: block;
-      width: 150px;
+  }
+
+  .changenote::before {
+      content:    "Change Note";
+      display:    block;
+      width:  150px;
       margin: -1.5em 0 0.5em 0;
-      font-weight: bold;
+      font-weight:    bold;
       border: 1px solid #cff6d9;
       background: #ffddef;
-      padding: 3px 1em;
-      }
-      .fact {
+      padding:    3px 1em;
+  }
+
+
+  .fact  {
       padding: 0.5em;
       margin: 1em 0;
       position: relative;
       clear: both;
       background-color: #ffeecc;
       border: 1px solid black
-      }
-      table {
-      border-collapse: collapse;
-      }
-      table,
-      td,
-      th {
-      border: 1px solid black;
-      }
-      caption {
-      font-weight: bold;
-      text-align: left;
-      }
-      code {
-      color: #ff4500;
-      }
-      pre, .hljs {
-      color: #ff4500!important;
-      background-color: inherit!important;
-      }
-      .ruletable pre .hljs {
-      background-color: #DDDDFF;
-      }
-      .space {
-      display: block;
-      height: 1px;
-      background-color: black;
-      margin: 0;
-      }
-      .defcap {
-      margin: 0;
-      font-size: 1em;
-      color: black;
-      font-weight: bold;
-      }
-      ul.cols {
-      columns: 2;
-      }
-    </style>
-  </head>
-  <body>
-    <section id='abstract'>
-      <p>  This document describes a precise semantics for the
-        [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]
-        and [[[RDF12-SCHEMA]]] [[RDF12-SCHEMA]].
-        It defines a number of distinct entailment regimes and corresponding patterns of entailment.
-        It is part of a suite of documents which comprise the full specification of RDF 1.2.
-      </p>
-    </section>
-    <section id='sotd' class="updateable-rec">
-      <p>This document is part of RDF 1.2 document suite.
-        This is a revision of the 2014 Semantics specification for RDF
-        [[RDF11-MT]] and supersedes that document.
-        The technical content of the document is unchanged, only minor editorial changes have been made.
-      </p>
-      <section id="related" data-include="./common/related.html"></section>
-    </section>
-    <section class='introductory'>
-      <h2 id="notes">Notes</h2>
-      <p class='changenote'>Notes in this style indicate changes from the 2004 RDF 1.0 semantics.</p>
-      <p class='technote'>Notes in this style are technical asides on obscure or recondite matters.</p>
-    </section>
+  }
+
+    table { border-collapse:collapse; }
+    table, td, th { border:1px solid black; }
+    caption { font-weight: bold; text-align: left ; }
+    code {color: #ff4500;}  /* Old W3C Style */
+  </style>
+</head>
+<body>
+<section id='abstract'>
+  <p>  This document describes a precise semantics for the
+    [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]
+    and [[[RDF12-SCHEMA]]] [[RDF12-SCHEMA]].
+    It defines a number of distinct entailment regimes and corresponding patterns of entailment.
+    It is part of a suite of documents which comprise the full specification of RDF 1.2.</p>
+</section>
+
+<section id='sotd' class="updateable-rec">
+  <p>This document is part of RDF 1.2 document suite.
+    This is a revision of the 2014 Semantics specification for RDF
+    [[RDF11-MT]] and supersedes that document.
+    The technical content of the document is unchanged, only minor editorial changes have been made.</a>
+  </p>
+
+  <section id="related" data-include="./common/related.html"></section>
+</section>
+
+   <section class='introductory'><h2 id="notes">Notes</h2>
+     <p class='changenote'>Notes in this style indicate changes from the 2004 RDF 1.0 semantics.</p>
+     <p class='technote'>Notes in this style are technical asides on obscure or recondite matters.</p></section>
     <section>
       <h2 id="introduction">Introduction</h2>
       <p>
         This document defines a model-theoretic semantics for RDF graphs
         and the RDF and RDFS vocabularies, providing an exact formal specification
         of when truth is preserved by transformations of RDF or operations which derive
-        RDF content from other RDF. 
-      </p>
+        RDF content from other RDF. </p>
+
     </section>
+
     <section id="conformance">
       <p>This specification, <em>RDF 1.2 Semantics</em>,
         is normative for RDF semantics and the validity of RDF inference processes.
@@ -177,13 +139,11 @@
         or specified by this semantics,
         including social issues of how IRIs are assigned meanings in use
         and how the referents of IRIs are related to Web content expressed in other media
-        such as natural language texts. 
-      </p>
+        such as natural language texts. </p>
     </section>
+
     <section id="extensions">
-      <span id="semantic-extensions-and-entailment-regimes">
-        <!-- obsolete identifier -->
-      </span>
+      <span id="semantic-extensions-and-entailment-regimes"><!-- obsolete identifier --></span>
       <h2>Semantic Extensions and Entailment Regimes</h2>
       <p>RDF is intended for use as a base notation for a variety of extended notations
         such as OWL [[?OWL2-OVERVIEW]] and RIF [[?RIF-OVERVIEW]],
@@ -193,1836 +153,2009 @@
         When such extra meanings are assumed,
         a given RDF graph may support more extensive entailments than are sanctioned by the basic RDF semantics.
         In general, the more assumptions that are made about the meanings of IRIs in an RDF graph,
-        the more entailments follow from those assumptions. 
-      </p>
+        the more entailments follow from those assumptions. </p>
+
       <p>A particular such set of semantic assumptions is called a <dfn>semantic extension</dfn>.
         Each <a>semantic extension</a> defines an <dfn>entailment regime</dfn>
         (used here in the same sense as in the [[[?SPARQL12-ENTAILMENT]]] recommendation [[?SPARQL12-ENTAILMENT]] )
         of entailments which are valid under that extension.
         RDFS, described later in this document, is one such <a>semantic extension</a>.
         We will refer to entailment regimes by names such as <em> RDFS entailment</em>,
-        <em>D-entailment</em>, etc. 
-      </p>
+        <em>D-entailment</em>, etc. </p>
+
       <p><a>Semantic extension</a>s MAY impose special syntactic conditions or restrictions upon RDF graphs,
         such as requiring certain triples to be present,
         or prohibiting particular combinations of IRIs in triples,
         and MAY consider RDF graphs which do not conform to these conditions to be errors.
-        For example, RDF statements of the form <br><br>
-        <code>ex:a rdfs:subClassOf "Thing"^^xsd:string .</code><br><br>
+        For example, RDF statements of the form <br/><br/>
+        <code>ex:a rdfs:subClassOf "Thing"^^xsd:string .</code><br/><br/>
         are prohibited in the OWL <a>semantic extension</a> based on description logics [[?OWL2-SYNTAX]].
         In such cases, basic RDF operations such as taking a subset of triples,
         or combining RDF graphs, may cause syntax errors in parsers which recognize the extension conditions.
         None of the <a>semantic extension</a>s normatively defined in this document
-        impose such syntactic restrictions on RDF graphs.
-      </p>
+        impose such syntactic restrictions on RDF graphs.</p>
+
       <p>All entailment regimes MUST be <dfn class="no-export lint-ignore">monotonic</dfn> extensions
         of the simple entailment regime described in the document,
         in the sense that if A simply <a>entail</a>s B then A also entails B under any extended notion of entailment,
         provided that any syntactic conditions of the extension are also satisfied.
         Put another way, a <a>semantic extension</a> cannot "cancel" an entailment
         made by a weaker entailment regime,
-        although it can treat the result as a syntax error.
-      </p>
+        although it can treat the result as a syntax error.</p>
     </section>
-    <section id="notation">
-      <h2>Notation and Terminology</h2>
-      <p>
-        This document uses the following terminology for describing RDF graph syntax, all as defined in the companion RDF Concepts specification [[!RDF12-CONCEPTS]]:
-        <dfn data-cite="RDF12-CONCEPTS#dfn-iri">IRI</dfn><span id="dfn-iri"></span>,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-triple" data-lt="triple">RDF triple</dfn>
-        <span id="dfn-rdf-triple">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-graph" data-lt="graph">RDF graph</dfn>
-        <span id="dfn-rdf-graph">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-subject">subject</dfn>
-        <span id="dfn-subject">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</dfn>
-        <span id="dfn-predicate">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-object">object</dfn>
-        <span id="dfn-object">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-source">RDF source</dfn>
-        <span id="dfn-rdf-source">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-node">node</dfn>
-        <span id="dfn-node">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</dfn>
-        <span id="dfn-blank-node">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-literal">literal</dfn>
-        <span id="dfn-literal">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        ,
-        <dfn data-cite="RDF12-CONCEPTS#dfn-graph-isomorphism">isomorphic</dfn><span id="dfn-isomorphic"></span>, and
-        <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn>
-        <span id="dfn-rdf-dataset">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        .
-        All the definitions in this document apply unchanged to
-        <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-triple">generalized RDF triples</dfn>, 
-        <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-graph">generalized RDF graphs</dfn>, and
-        <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-dataset">generalized RDF datasets</dfn>.
-      </p>
-      <p>An <dfn class="export">interpretation</dfn> is a mapping from IRIs and literals into a set,
-        together with some constraints upon the set and the mapping.
-        This document defines various notions of interpretation,
-        each corresponding in a standard way to an entailment regime.
-        These are identified by prefixes such as <em>simple interpretation</em>, etc.,
-        and are defined in later sections.
-        The unqualified term <em>interpretation</em> is usually used to refer to
-        any compatible kind of interpretation in general,
-        but if clear from the context might refer to a specific kind of interpretation.
-      </p>
-      <p>The word <dfn id="dfn-denote" data-cite="RDF12-CONCEPTS#dfn-denote" data-lt="denote" data-local-lt="denoted">denotes</dfn>
-        is used here for the relationship between an <a>IRI</a> or <a>literal</a>
-        and what it refers to in a given interpretation,
-        itself called the <dfn id="dfn-referent" data-cite="RDF12-CONCEPTS#dfn-referent">referent</dfn>.
-        (The phrase <dfn class="no-export lint-ignore">refer to</dfn> is often used instead of denote and 
-        <dfn class="no-export lint-ignore">denotation</dfn> instead of referent.)
-        IRI meanings may also be determined by other constraints external to the RDF semantics;
-        when we wish to refer to such an externally defined naming relationship,
-        we will use the word <dfn class="no-export lint-ignore" data-local-lt="identified">identify</dfn> and its cognates.
-        For example, the fact that the IRI <code>http://www.w3.org/2001/XMLSchema#decimal</code>
-        is widely used as the name of a datatype described in the XML Schema document [[XMLSCHEMA11-2]]
-        might be described by saying that the IRI <em>identifies</em> that datatype.
-        If an IRI identifies something it may or may not denote it in a given interpretation,
-        depending on how the semantics is specified.
-        For example, an IRI used as a graph name <a>identify</a>ing a named graph in an
-        <a>RDF dataset</a> may denote something different from the graph it identifies.
-      </p>
-      <p>Throughout this document, the equality sign `=` indicates strict identity.
-        The statement "A = B" means that there is one entity which both expressions "A" and "B" denote. 
-        Angle brackets &lt; x, y &gt; are used to indicate an ordered pair of x and y.
-      </p>
-      <p>Throughout this document, <a>RDF graph</a>s and other fragments of RDF abstract syntax
-        are written using the notational conventions of the Turtle syntax [[!TURTLE]].
-        The namespace prefixes <code>rdf:</code> <code>rdfs:</code> and <code>xsd:</code>
-        are used as in [[!RDF12-CONCEPTS]],
-        <a data-cite="RDF12-CONCEPTS#dfn-rdf-vocabulary">RDF vocabularies</a>.
-        When the exact IRI does not matter, the prefix <code>ex:</code> is used.
-        When stating general rules or conditions we use three-character variables such as
-        aaa, xxx, sss  to indicate arbitrary IRIs, literals,
-        or other components of RDF syntax.
-        Some cases are illustrated by node-arc diagrams showing the graph structure directly.
-      </p>
-      <p>A <dfn>name</dfn> is any IRI or literal. A literal contains
-        two <a>names</a>: itself and its internal type
-        IRI. A <dfn>vocabulary</dfn> is a set of <a>names</a>.
-      </p>
-      <p>The <dfn>empty graph</dfn> is the empty set of triples.</p>
-      <p>A <dfn>subgraph</dfn> of an <a>RDF graph</a> is a subset of the triples in the graph.
-        A <a>triple</a> is identified with the singleton set containing it,
-        so that each triple in a graph is considered to be a subgraph.
-        A <dfn>proper subgraph</dfn> is a proper subset of the triples in the graph.
-      </p>
-      <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
-      <p>Suppose that M is a functional mapping from a set of blank
-        nodes to some set of literals, blank nodes and IRIs. Any graph obtained
-        from a graph <em>G</em> by replacing some or all of the blank nodes <em>N</em> in <em>G</em> by <em>M(N)</em> is
-        an <dfn>instance</dfn> of <em>G</em>. Any graph is an instance of itself,
-        an instance of an instance of <em>G</em> is an instance of <em>G</em>,
-        and if <em>H</em> is an instance of <em>G</em> then every triple in <em>H</em> is an instance of at least one triple
-        in <em>G</em>.
-      </p>
-      <p>An <dfn class="no-export lint-ignore">instance with respect to</dfn> a vocabulary
-        V is an <a>instance</a> in which all the
-        <a>names</a> in the instance that were substituted
-        for blank nodes in the original are <a>names</a>
-        from V.
-      </p>
-      <p>A <dfn>proper instance</dfn> of a graph
-        is an <a>instance</a> in which a blank node has been replaced by a <a>name</a>, or two blank
-        nodes in the graph have been mapped into the same node in the instance. 
-      </p>
-      <p>Two graphs are <a data-cite="RDF12-CONCEPTS#dfn-graph-isomorphism">isomorphic</a> when each maps into the other by a 1:1 mapping on blank nodes. Isomorphic graphs are mutual instances with an invertible instance
-        mapping. As blank nodes have no particular identity beyond their location in a graph, we will often treat isomorphic graphs as identical.
-      </p>
-      <p >An RDF graph is <dfn>lean</dfn> if it has no instance which is
-        a <a>proper subgraph</a> of itself. Non-lean graphs have internal redundancy
-        and express the same content as their lean <a>subgraphs</a>. For example, the graph
-      </p>
-      <pre class="example" title="Non-lean graph">
+
+  <section id="notation">
+    <h2>Notation and Terminology</h2>
+
+    <p>This document uses the following terminology for describing RDF graph syntax, all as defined in the companion RDF Concepts specification [[!RDF12-CONCEPTS]]:
+      <dfn data-cite="RDF12-CONCEPTS#dfn-iri">IRI</dfn><span id="dfn-iri"></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-triple" data-lt="triple">RDF triple</dfn><span id="dfn-rdf-triple"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-graph" data-lt="graph">RDF graph</dfn><span id="dfn-rdf-graph"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-subject">subject</dfn><span id="dfn-subject"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-predicate">predicate</dfn><span id="dfn-predicate"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-object">object</dfn><span id="dfn-object"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-source">RDF source</dfn><span id="dfn-rdf-source"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-node">node</dfn><span id="dfn-node"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-blank-node">blank node</dfn><span id="dfn-blank-node"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-literal">literal</dfn><span id="dfn-literal"><!-- refer to RDF Concepts term --></span>,
+      <dfn data-cite="RDF12-CONCEPTS#dfn-graph-isomorphism">isomorphic</dfn><span id="dfn-isomorphic"></span>, and
+      <dfn data-cite="RDF12-CONCEPTS#dfn-rdf-dataset" data-lt="dataset">RDF dataset</dfn><span id="dfn-rdf-dataset"><!-- refer to RDF Concepts term --></span>.
+      All the definitions in this document apply unchanged to
+      <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-triple">generalized RDF triples</dfn>, 
+      <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-graph">generalized RDF graphs</dfn>, and
+      <dfn data-cite="RDF12-CONCEPTS#dfn-generalized-rdf-dataset">generalized RDF datasets</dfn>.</p>
+
+    <p>An <dfn class="export">interpretation</dfn> is a mapping from IRIs and literals into a set,
+      together with some constraints upon the set and the mapping.
+      This document defines various notions of interpretation,
+      each corresponding in a standard way to an entailment regime.
+      These are identified by prefixes such as <em>simple interpretation</em>, etc.,
+      and are defined in later sections.
+      The unqualified term <em>interpretation</em> is usually used to refer to
+      any compatible kind of interpretation in general,
+      but if clear from the context might refer to a specific kind of interpretation.</p>
+
+    <p>The word <dfn id="dfn-denote" data-cite="RDF12-CONCEPTS#dfn-denote" data-lt="denote" data-local-lt="denoted">denotes</dfn>
+      is used here for the relationship between an <a>IRI</a> or <a>literal</a>
+      and what it refers to in a given interpretation,
+      itself called the <dfn id="dfn-referent" data-cite="RDF12-CONCEPTS#dfn-referent">referent</dfn>.
+      (The phrase <dfn class="no-export lint-ignore">refer to</dfn> is often used instead of denote and 
+      <dfn class="no-export lint-ignore">denotation</dfn> instead of referent.)
+      IRI meanings may also be determined by other constraints external to the RDF semantics;
+      when we wish to refer to such an externally defined naming relationship,
+      we will use the word <dfn class="no-export lint-ignore" data-local-lt="identified">identify</dfn> and its cognates.
+      For example, the fact that the IRI <code>http://www.w3.org/2001/XMLSchema#decimal</code>
+      is widely used as the name of a datatype described in the XML Schema document [[XMLSCHEMA11-2]]
+      might be described by saying that the IRI <em>identifies</em> that datatype.
+      If an IRI identifies something it may or may not denote it in a given interpretation,
+      depending on how the semantics is specified.
+      For example, an IRI used as a graph name <a>identify</a>ing a named graph in an
+      <a>RDF dataset</a> may denote something different from the graph it identifies.</p>
+
+    <p>Throughout this document, the equality sign `=` indicates strict identity.
+      The statement "A = B" means that there is one entity which both expressions "A" and "B" denote. 
+      Angle brackets &lt; x, y &gt; are used to indicate an ordered pair of x and y.</p>
+
+    <p>Throughout this document, <a>RDF graph</a>s and other fragments of RDF abstract syntax
+      are written using the notational conventions of the Turtle syntax [[!TURTLE]].
+      The namespace prefixes <code>rdf:</code> <code>rdfs:</code> and <code>xsd:</code>
+      are used as in [[!RDF12-CONCEPTS]],
+      <a data-cite="RDF12-CONCEPTS#dfn-rdf-vocabulary">RDF vocabularies</a>.
+      When the exact IRI does not matter, the prefix <code>ex:</code> is used.
+      When stating general rules or conditions we use three-character variables such as
+      aaa, xxx, sss  to indicate arbitrary IRIs, literals,
+      or other components of RDF syntax.
+      Some cases are illustrated by node-arc diagrams showing the graph structure directly.</p>
+
+    <p>A <dfn>name</dfn> is any IRI or literal. A literal contains
+      two <a>names</a>: itself and its internal type
+      IRI. A <dfn>vocabulary</dfn> is a set of <a>names</a>.</p>
+
+    <p>The <dfn>empty graph</dfn> is the empty set of triples.</p>
+
+    <p>A <dfn>subgraph</dfn> of an <a>RDF graph</a> is a subset of the triples in the graph.
+      A <a>triple</a> is identified with the singleton set containing it,
+      so that each triple in a graph is considered to be a subgraph.
+      A <dfn>proper subgraph</dfn> is a proper subset of the triples in the graph.</p>
+
+    <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
+
+    <p>Suppose that M is a functional mapping from a set of blank
+      nodes to some set of literals, blank nodes and IRIs. Any graph obtained
+      from a graph G by replacing some or all of the blank nodes N in G by M(N) is
+      an <dfn>instance</dfn> of G. Any graph is an instance of itself,
+      an instance of an instance of G is an instance of G,
+      and if H is an instance of G then every triple in H is an instance of at least one triple
+      in G.</p>
+
+    <p>An <dfn class="no-export lint-ignore">instance with respect to</dfn> a vocabulary
+      V is an <a>instance</a> in which all the
+      <a>names</a> in the instance that were substituted
+      for blank nodes in the original are <a>names</a>
+      from V.</p>
+
+    <p>A <dfn>proper instance</dfn> of a graph
+      is an <a>instance</a> in which a blank node has been replaced by a <a>name</a>, or two blank
+      nodes in the graph have been mapped into the same node in the instance. </p>
+
+    <p>Two graphs are <a data-cite="RDF12-CONCEPTS#dfn-graph-isomorphism">isomorphic</a> when each maps into the other by a 1:1 mapping on blank nodes. Isomorphic graphs are mutual instances with an invertible instance
+      mapping. As blank nodes have no particular identity beyond their location in a graph, we will often treat isomorphic graphs as identical.</p>
+
+    <p >An RDF graph is <dfn>lean</dfn> if it has no instance which is
+      a <a>proper subgraph</a> of itself. Non-lean graphs have internal redundancy
+      and express the same content as their lean <a>subgraphs</a>. For example, the graph</p>
+
+    <pre class="example" title="Non-lean graph">
       ex:a ex:p _:x .
       _:y ex:p _:x .
     </pre>
-      <p >is not lean, but</p>
-      <pre class="example" title="Lean graph">
+
+    <p >is not lean, but</p>
+
+    <pre class="example" title="Lean graph">
       ex:a ex:p _:x .
       _:x ex:p _:x .
     </pre>
-      <p>is lean. <a>Ground</a> graphs are lean. </p>
-      <section id="unions_merges">
-        <h3>Shared blank nodes, unions and merges</h3>
-        <p>Graphs share <a>blank nodes</a> only if they are derived from graphs
-          described by documents or other structures (such as an RDF dataset)
-          that explicitly provide for the sharing of blank nodes between different RDF graphs.
-          Simply downloading a web document does not mean that the blank nodes in a resulting RDF
-          graph are the same as the blank nodes coming from other downloads of
-          the same document or from the same <a>RDF source</a>.
-        </p>
-        <p> RDF applications which manipulate concrete syntaxes for RDF which use <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifiers</a>
-          should take care to keep track of the identity of the blank nodes they identify.
-          Blank node identifiers often have a local scope,
-          so when RDF from different sources is combined,
-          identifiers may have to be changed in order to avoid accidental conflation
-          of distinct blank nodes.
-        </p>
-        <p> For example, two documents may both use the blank node identifier "<code>_:x</code>"
-          to identify a blank node, but unless these documents are in a shared identifier scope
-          or are derived from a common source,
-          the occurrences of "<code>_:x</code>" in one document
-          will identify a different blank node than the one in the graph described by the other document.
-          When graphs are formed by combining RDF from multiple sources,
-          it may be necessary to <dfn class="no-export lint-ignore">standardize</dfn> apart the blank node identifiers
-          by replacing them by others which do not occur in the other document(s).
-          For example, the two graphs represented  by the following texts:
-        </p>
-        <p><code>ex:a ex:p _:x . </code><br><br>
-          <img src="RDF12SemanticsDiagrams/example1.svg" alt="Graph 1">
-        </p>
-        <p><code>ex:b ex:q _:x . </code><br><br>
-          <img src="RDF12SemanticsDiagrams/example2.svg" alt="Graph 2">
-        </p>
-        <p>contain four nodes. Their union would therefore also contain four nodes:</p>
-        <p><img src="RDF12SemanticsDiagrams/example4.svg" alt="Union Graph"></p>
-        <p>However, the document formed by simply concatenating these textual surface representations:</p>
-        <p><code>ex:a ex:p _:x .<br>
-          ex:b ex:q _:x .</code><br>
-        </p>
-        <p>describes a graph containing three nodes:</p>
-        <p><img src="RDF12SemanticsDiagrams/example3.svg" alt="Incorrect Union Graph"></p>
-        <p> since the two occurrences of the blank node identifier "<code>_:x</code>" occurring in a common identifier scope identify the same blank node. The four-node union of these two graphs is more properly described by a surface form such as:</p>
-        <pre class="nohighlight">ex:a ex:p _:x1 .
-          ex:b ex:q _:x2 .
-        </pre>
-        <p>in which the blank node identifiers have been <a data-lt="standardize">standardized</a>
-          apart to avoid conflating the distinct blank nodes.
-          (The particular blank node identifiers used have no significance, only that they are distinct.)
-        </p>
-        <p>It is possible for two or more graphs to share a blank node,
-          for example if they are <a>subgraphs</a> of a single larger graph or derived from a common source.
-          In this case, the union of a set of graphs preserves the identity of blank nodes shared between the graphs.
-          In general, the union of a set of RDF graphs accurately represents the same semantic content
-          as the graphs themselves, whether or not they share blank nodes.
-        </p>
-        <p>A related operation, called <dfn class="no-export lint-ignore">merging</dfn>,
-          takes the union after forcing any shared blank nodes,
-          which occur in more than one graph, to be distinct in each graph.
-          The resulting graph is called the <dfn class="no-export lint-ignore">merge</dfn>.
-          The merge of <a>subgraphs</a> of a graph may be larger than the original graph.
-          For example, the result of merging the two singleton subgraphs of the three-node graph
-        </p>
-        <p><img src="RDF12SemanticsDiagrams/example3.svg" alt="Three-node Graph"></p>
-        <p>is the four-node graph</p>
-        <p><img src="RDF12SemanticsDiagrams/example4.svg" alt="Four-node Graph"></p>
-        <p>The union is always an instance of the merge. If graphs have no blank nodes in common, then their merge and union are identical. </p>
-      </section>
+
+    <p>is lean. <a>Ground</a> graphs are lean. </p>
+
+  <section id="unions_merges">
+    <h3>Shared blank nodes, unions and merges</h3>
+
+    <p>Graphs share <a>blank nodes</a> only if they are derived from graphs
+      described by documents or other structures (such as an RDF dataset)
+      that explicitly provide for the sharing of blank nodes between different RDF graphs.
+      Simply downloading a web document does not mean that the blank nodes in a resulting RDF
+      graph are the same as the blank nodes coming from other downloads of
+      the same document or from the same <a>RDF source</a>.</p>
+
+    <p> RDF applications which manipulate concrete syntaxes for RDF which use <a data-cite="RDF12-CONCEPTS#dfn-blank-node-identifier">blank node identifiers</a>
+      should take care to keep track of the identity of the blank nodes they identify.
+      Blank node identifiers often have a local scope,
+      so when RDF from different sources is combined,
+      identifiers may have to be changed in order to avoid accidental conflation
+      of distinct blank nodes.</p>
+
+    <p> For example, two documents may both use the blank node identifier "<code>_:x</code>"
+      to identify a blank node, but unless these documents are in a shared identifier scope
+      or are derived from a common source,
+      the occurrences of "<code>_:x</code>" in one document
+      will identify a different blank node than the one in the graph described by the other document.
+      When graphs are formed by combining RDF from multiple sources,
+      it may be necessary to <dfn class="no-export lint-ignore">standardize</dfn> apart the blank node identifiers
+      by replacing them by others which do not occur in the other document(s).
+      For example, the two graphs represented  by the following texts:</p>
+
+    <p><code>ex:a ex:p _:x . </code><br/><br/>
+      <img src="RDF12SemanticsDiagrams/example1.svg" alt="Graph 1" /></p>
+
+    <p><code>ex:b ex:q _:x . </code><br/><br/>
+      <img src="RDF12SemanticsDiagrams/example2.svg" alt="Graph 2" ></p>
+
+    <p>contain four nodes. Their union would therefore also contain four nodes:</p>
+
+    <p><img src="RDF12SemanticsDiagrams/example4.svg" alt="Union Graph"></p>
+
+    <p>However, the document formed by simply concatenating these textual surface representations:</p>
+
+    <p><code>ex:a ex:p _:x .<br/>
+    ex:b ex:q _:x .</code><br/></p>
+
+    <p>describes a graph containing three nodes:</p>
+
+    <p><img src="RDF12SemanticsDiagrams/example3.svg" alt="Incorrect Union Graph"></p>
+
+    <p> since the two occurrences of the blank node identifier "<code>_:x</code>" occurring in a common identifier scope identify the same blank node. The four-node union of these two graphs is more properly described by a surface form such as:</p>
+
+    <p><code>ex:a ex:p _:x1 .<br/>
+      ex:b ex:q _:x2 .</code></p>
+
+    <p>in which the blank node identifiers have been <a data-lt="standardize">standardized</a>
+      apart to avoid conflating the distinct blank nodes.
+      (The particular blank node identifiers used have no significance, only that they are distinct.)</p>
+
+    <p>It is possible for two or more graphs to share a blank node,
+      for example if they are <a>subgraphs</a> of a single larger graph or derived from a common source.
+      In this case, the union of a set of graphs preserves the identity of blank nodes shared between the graphs.
+      In general, the union of a set of RDF graphs accurately represents the same semantic content
+      as the graphs themselves, whether or not they share blank nodes.</p>
+
+    <p>A related operation, called <dfn class="no-export lint-ignore">merging</dfn>,
+      takes the union after forcing any shared blank nodes,
+      which occur in more than one graph, to be distinct in each graph.
+      The resulting graph is called the <dfn class="no-export lint-ignore">merge</dfn>.
+      The merge of <a>subgraphs</a> of a graph may be larger than the original graph.
+      For example, the result of merging the two singleton subgraphs of the three-node graph</p>
+
+    <p><img src="RDF12SemanticsDiagrams/example3.svg" alt="Three-node Graph"></p>
+
+    <p>is the four-node graph</p>
+
+    <p><img src="RDF12SemanticsDiagrams/example4.svg" alt="Four-node Graph"></p>
+
+    <p>The union is always an instance of the merge. If graphs have no blank nodes in common, then their merge and union are identical. </p>
+  </section>
+</section>
+
+<section id="simple">
+  <h2>Simple Interpretations</h2>
+
+  <p>This section defines the basic notions of simple interpretation and truth for RDF graphs.
+    All <a>semantic extension</a>s of any vocabulary or higher-level notation encoded in RDF
+    MUST conform to these minimal truth conditions.
+    Other <a>semantic extension</a>s may extend and add to these,
+    but they MUST NOT modify or negate them.
+    For example, because simple interpretations are mappings which apply to IRIs,
+    a <a>semantic extension</a> cannot interpret different occurrences of a single IRI differently.</p>
+
+  <p>The entire semantics applies to <a>RDF graph</a>s, not to <a>RDF source</a>s.
+    An <a>RDF source</a> has a semantic meaning only through the graph that is its value at a given time,
+    or in a given state.
+    Graphs cannot change their semantics with time.</p>
+
+
+  <p>A <dfn data-lt="simply entail">simple interpretation</dfn> I is a structure consisting of:</p>
+
+  <table>
+    <caption>Definition of a simple interpretation.</caption>
+    <tr>
+          <td class="semantictable">1. A non-empty set IR of resources, called the domain or universe
+              of I.
+        <p>2. <span >A set IP, called the set of properties of I.</span></p>
+            <p>3. A mapping IEXT from IP into the powerset of IR x IR i.e. the
+              set of sets of pairs &lt; x, y &gt; with x and y in IR .</p>
+        <p>4. A mapping IS from IRIs into (IR union IP)</p>
+        <p>5. A partial mapping IL from literals into IR </p>
+        <p><span style="background-color: Cyan;color: Black">6. An injective mapping RE from IR x IP x IR into IR, called the denotation of triple terms</span> </p>
+       </td>
+    </tr>
+  </table>
+
+  <div class="changenote">
+    <p>The 2004 RDF 1.0 semantics defined simple interpretations relative to a vocabulary.</p>
+    <p>In the 2004 RDF 1.0 semantics, IL was a total, rather than partial, mapping.</p>
+    <p>The 2004 RDF 1.0 specification divided literals into 'plain' literals
+      with no type and optional language tags, and typed literals.
+      Usage has shown that it is important that every literal have a type.
+      RDF 1.1 replaces plain literals without language tags by literals typed with
+      the XML Schema <code>string</code> datatype,
+      and introduces the special type <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
+      for language-tagged strings.
+      The full semantics for typed literals is given in the next section.</p>
+  </div>
+
+  <p class="technote">Simple interpretations are required to interpret all <a>names</a>,
+    and are therefore infinite.
+    This simplifies the exposition.
+    However, RDF can be interpreted using finite structures,
+    supporting decidable algorithms.
+    Details are given in <a href="#finite_interpretations" class="sectionRef"></a>. </p>
+
+  <p>IEXT(x), called the <dfn class="no-export lint-ignore">extension</dfn> of x,
+    is a set of pairs which identify the arguments for which the property is true,
+    that is, a binary relational extension.</p>
+
+  <p>The distinction between IR and IL will become significant below when the semantics of datatypes are defined.
+    IL is allowed to be partial because some literals may fail to have a referent. </p>
+
+  <p class="technote">It is conventional to map a relation name to a relational extension directly.
+    This however presumes that the vocabulary is segregated into relation names and individual names,
+    and RDF makes no such assumption.
+    Moreover, RDF allows an IRI to be used as a relation name applied to itself as an argument.
+    Such self-application structures are used in RDFS, for example.
+    The use of the IEXT mapping to distinguish the relation as an object from its relational extension
+    accommodates both of these requirements.
+    It also provides for a notion of RDFS 'class' which can be distinguished
+    from its set-theoretic extension.
+    A similar technique is used in the ISO/IEC Common Logic standard [[?ISO24707]].</p>
+
+  <p><span style="background-color: Cyan;color: Black"><s>The referent of a ground RDF graph in a simple interpretation I is then given by the following rules,
+    where the interpretation is also treated as a function from expressions (<a>names</a>, <a>triples</a> and <a>graphs</a>) to elements of the universe and truth values:</s></span></p>
+
+  <p><span style="background-color: Cyan;color: Black">The referent of a ground RDF graph in a simple interpretation I is given by an <i>interpretation</i> function I from expressions (<a>names</a>, <a>triples</a> and <a>graphs</a>) to elements of the universe and truth values, defined as follows:</span></p>
+
+  <table>
+    <caption>Semantic conditions for ground graphs.</caption>
+    <tbody>
+      <tr>
+        <td class="semantictable">if E is a literal then I(E) = IL(E)</td>
+      </tr>
+
+      <tr>
+        <td class="semantictable">if E is an IRI then I(E) = IS(E)</td>
+      </tr>
+
+    <tr>
+        <td class="semantictable"><span style="background-color: Cyan;color: Black">if E is a Triple Term then I(E) = RE(I(E.s), I(E.p), I(E.o))<br> where we write the subject, predicate, object of E as E.s, E.p, E.o, respectively.</span></td>
+      </tr>
+
+<tr>
+        <td class="semantictable">if E is a ground triple `s p o.`
+          then I(E) = true if<br/>
+          I(p) is in IP and the pair &lt;I(s),I(o)&gt;
+          is in IEXT(I(p))<br/>
+          otherwise I(E) = false.</td>
+      </tr>
+
+      <tr>
+        <td class="semantictable">if E is a ground RDF graph then I(E) = false if I(E') =
+          false for some triple E' in E, otherwise I(E) =true.</td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>If IL(E) is undefined for some literal E then E has no semantic value,
+    so any triple containing it will be false,
+    so any graph containing that triple will also be false.</p>
+
+  <p>The final condition implies that the empty graph (the empty set of triples) is always true.</p>
+
+  <p>The sets IP and IR may overlap, indeed IP can be a subset of IR.
+    Because of the domain conditions on IEXT,
+    the referent of the subject and object of any true triple will be in IR;
+    so any IRI which occurs in a graph both as a predicate and as a subject or object
+    will denote something in the intersection of IP and IR.</p>
+
+  <p><a>Semantic extensions</a> may impose further constraints upon interpretation mappings
+    by requiring some IRIs to denote in particular ways.
+    For example, D-interpretations, described below, require some IRIs,
+    understood as <a>identify</a>ing and referring to datatypes, to have a fixed referent.</p>
+
+  <section id="blank_nodes">
+    <h3>Blank nodes</h3>
+
+    <p>Blank nodes are treated as simply indicating the existence of a thing,
+      without using an IRI to <a>identify</a> any particular thing.
+      This is not the same as assuming that the blank node indicates an 'unknown' IRI.</p>
+
+    <p>Suppose I is a simple interpretation and A is a mapping from a set of blank nodes
+      to the universe IR of I.
+      Define the mapping [I+A] to be I on <a>names</a>,
+      and A on blank nodes on the set: [I+A](x)=I(x) when x is a <a>name</a>
+      and [I+A](x)=A(x) when x is a blank node;
+      and extend this mapping to triples and RDF graphs using the rules given above for ground graphs.
+      Then the semantic conditions for an RDF graph are:</p>
+
+    <table>
+      <caption>Semantic condition for blank nodes.</caption>
+      <tbody>
+        <tr>
+          <td class="semantictable">If E is an RDF graph then I(E) = true if [I+A](E) =
+          true for some mapping A from the set of blank nodes in E to IR, otherwise
+          I(E)= false.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>Mappings from blank nodes to referents are not part of the definition of a simple interpretation,
+      since the truth condition refers only to <em>some</em> such mapping.
+      Blank nodes themselves differ from other nodes in not being assigned
+      a referent by a simple interpretation, reflecting the intuition that
+      they have no 'global' meaning.</p>
+
+    <section id="shared_blank_nodes" class="informative">
+      <h3>Shared blank nodes (Informative)</h3>
+
+      <p> The semantics for blank nodes are stated in terms of the truth of a graph. However, when two (or more) graphs share a blank node, their meaning is not fully captured by treating them in isolation. For example, consider the overlapping graphs</p>
+
+      <p><img src="RDF12SemanticsDiagrams/example5.svg" alt="Overlapping Graphs" style="max-width: 100%"></p> 
+
+      <p> and a simple interpretation I over the universe {Alice, Bob, Monica, Ruth} with:<br/>
+        I(<code>ex:Alice</code>)=Alice, I(<code>ex:Bob</code>)=Bob, IEXT(I(<code>ex:hasChild</code>))={&lt;Alice,Monica&gt;,&lt;Bob,Ruth&gt; }<br/></p>
+
+      <p>Each of the inner graphs is true under this interpretation,
+        but the two of them together is not,
+        because the three-node graph says that Alice and Bob have a child together.
+        In order to capture the full meaning of graphs sharing a blank node,
+        it is necessary to consider the union graph containing all the triples
+        which contain the blank node.</p>
+
+      <p class="technote"> RDF graphs can be viewed as conjunctions of simple atomic sentences in first-order logic,
+        where blank nodes are free variables which are understood to be existential.
+        Taking the union of two graphs is then analogous to syntactic conjunction in this syntax.
+        RDF syntax has no explicit variable-binding quantifiers, so the truth conditions for any RDF graph
+        treat the free variables in that graph as existentially quantified in that graph.
+        Taking the union of graphs which share a blank node changes the implied quantifier scopes.</p>
     </section>
-    <section id="simple">
-      <h2>Simple Interpretations</h2>
-      <p>This section defines the basic notions of simple interpretation and truth for RDF graphs.
-        All <a>semantic extension</a>s of any vocabulary or higher-level notation encoded in RDF
-        MUST conform to these minimal truth conditions.
-        Other <a>semantic extension</a>s may extend and add to these,
-        but they MUST NOT modify or negate them.
-        For example, because simple interpretations are mappings which apply to IRIs,
-        a <a>semantic extension</a> cannot interpret different occurrences of a single IRI differently.
-      </p>
-      <p>The entire semantics applies to <a>RDF graph</a>s, not to <a>RDF source</a>s.
-        An <a>RDF source</a> has a semantic meaning only through the graph that is its value at a given time,
-        or in a given state.
-        Graphs cannot change their semantics with time.
-      </p>
-      <p>A <dfn data-lt="simply entail">simple interpretation</dfn> <em>I</em> is a structure consisting of:</p>
-      <section class="notoc">
-        <h6 class="defcap">Definition of a Simple Interpretation</h6>
-        <div class="semantictable">
-          <ol>
-            <li>A non-empty set <em>IR</em> of resources, called the domain or universe of <em>I</em>.</li>
-            <li>A set <em>IP</em>, called the set of properties of <em>I</em>.</li>
-            <li>A mapping <em>IEXT</em> from <em>IP</em> into the powerset of <em>IR</em> x <em>IR</em>, i.e., the set of sets of pairs <em>&lt;x, y&gt;</em> with <em>x</em> and <em>y</em> in <em>IR</em>.</li>
-            <li>A mapping <em>IS</em> from <em>IRIs</em> into (<em>IR</em> union <em>IP</em>).</li>
-            <li>A partial mapping <em>IL</em> from literals into <em>IR</em>.</li>
-          </ol>
-        </div>
-      </section>
-      <div class="changenote">
-        <p>The 2004 RDF 1.0 semantics defined simple interpretations relative to a vocabulary.</p>
-        <p>In the 2004 RDF 1.0 semantics, IL was a total, rather than partial, mapping.</p>
-        <p>The 2004 RDF 1.0 specification divided literals into 'plain' literals
-          with no type and optional language tags, and typed literals.
-          Usage has shown that it is important that every literal have a type.
-          RDF 1.1 replaces plain literals without language tags by literals typed with
-          the XML Schema <code>string</code> datatype,
-          and introduces the special type <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
-          for language-tagged strings.
-          The full semantics for typed literals is given in the next section.
-        </p>
-      </div>
-      <p class="technote">Simple interpretations are required to interpret all <a>names</a>,
-        and are therefore infinite.
-        This simplifies the exposition.
-        However, RDF can be interpreted using finite structures,
-        supporting decidable algorithms.
-        Details are given in <a href="#finite_interpretations" class="sectionRef"></a>. 
-      </p>
-      <p><em>IEXT(x)</em>, called the <dfn class="no-export lint-ignore">extension</dfn> of <em>x</em>,
-        is a set of pairs which identify the arguments for which the property is true,
-        that is, a binary relational extension.
-      </p>
-      <p>The distinction between <em>IR</em> and <em>IL</em> will become significant below when the semantics of datatypes are defined.
-        IL is allowed to be partial because some literals may fail to have a referent. 
-      </p>
-      <p class="technote">It is conventional to map a relation name to a relational extension directly.
-        This however presumes that the vocabulary is segregated into relation names and individual names,
-        and RDF makes no such assumption.
-        Moreover, RDF allows an IRI to be used as a relation name applied to itself as an argument.
-        Such self-application structures are used in RDFS, for example.
-        The use of the <em>IEXT</em> mapping to distinguish the relation as an object from its relational extension
-        accommodates both of these requirements.
-        It also provides for a notion of RDFS 'class' which can be distinguished
-        from its set-theoretic extension.
-        A similar technique is used in the ISO/IEC Common Logic standard [[?ISO24707]].
-      </p>
-      <p>The referent of a ground RDF graph in a simple interpretation <em>I</em> is then given by the following rules,
-        where the interpretation is also treated as a function from expressions (<a>names</a>, <a>triples</a> and <a>graphs</a>) to elements of the universe and truth values:
-      </p>
-      <section class="notoc">
-        <h6 class="defcap">Semantic Conditions for Ground Graphs</h6>
-        <div class="semantictable">
-          <p>If <em>E</em> is a literal, then <em>I(E) = IL(E)</em></p>
-          <span class="space"></span>
-          <p>If <em>E</em> is an IRI, then <em>I(E) = IS(E)</em></p>
-          <span class="space"></span>
-          <p>If <em>E</em> is a ground triple `s p o.`, <em>I(p)</em>
-            is in <em>IP</em> and the pair &lt;<em>I(s)</em>, <em>I(o)</em>&gt;
-            is in <em>IEXT(I(p))</em>, then <em>I(E) = true</em>;
-            otherwise, <em>I(E) = false</em>.
-          </p>
-          <span class="space"></span>
-          <p>If <em>E</em> is a ground RDF graph and <em>I(E') = false</em> for some triple <em>E'</em> in <em>E</em>, then <em>I(E) = false</em>; otherwise, <em>I(E) = true</em>.
-          </p>
-        </div>
-      </section>
-      <p>If IL(E) is undefined for some literal <em>E</em> then <em>E</em> has no semantic value,
-        so any triple containing it will be false,
-        so any graph containing that triple will also be false.
-      </p>
-      <p>The final condition implies that the empty graph (the empty set of triples) is always true.</p>
-      <p>The sets IP and IR may overlap, indeed IP can be a subset of IR.
-        Because of the domain conditions on IEXT,
-        the referent of the subject and object of any true triple will be in IR;
-        so any IRI which occurs in a graph both as a predicate and as a subject or object
-        will denote something in the intersection of IP and IR.
-      </p>
-      <p><a>Semantic extensions</a> may impose further constraints upon interpretation mappings
-        by requiring some IRIs to denote in particular ways.
-        For example, D-interpretations, described below, require some IRIs,
-        understood as <a>identify</a>ing and referring to datatypes, to have a fixed referent.
-      </p>
-      <section id="blank_nodes">
-        <h3>Blank nodes</h3>
-        <p>Blank nodes are treated as simply indicating the existence of a thing,
-          without using an IRI to <a>identify</a> any particular thing.
-          This is not the same as assuming that the blank node indicates an 'unknown' IRI.
-        </p>
-        <p>Suppose <em>I</em> is a simple interpretation and A is a mapping from a set of blank nodes
-          to the universe IR of I.
-          Define the mapping <em>[I+A]</em> to be <em>I</em> on <a>names</a>,
-          and A on blank nodes on the set: <em>[I+A](x)=I(x)</em> when <em>x</em> is a <a>name</a>
-          and <em>[I+A](x)=A(x)</em> when <em>x</em> is a blank node;
-          and extend this mapping to triples and RDF graphs using the rules given above for ground graphs.
-          Then the semantic conditions for an RDF graph are:
-        </p>
-        <section class="notoc">
-          <h6 class="defcap">Semantic Condition for Blank Nodes</h6>
-          <div class="semantictable">
-            <p>If <em>E</em> is an RDF graph and <em>[I + A](E) = true</em>
-              for some mapping <em>A</em> from the set of blank nodes in <em>E</em>
-              to <em>IR</em>, then <em>I(E) = true</em>;
-              otherwise, <em>I(E) = false</em>.
-            </p>
-          </div>
-        </section>
-        <p>Mappings from blank nodes to referents are not part of the definition of a simple interpretation,
-          since the truth condition refers only to <em>some</em> such mapping.
-          Blank nodes themselves differ from other nodes in not being assigned
-          a referent by a simple interpretation, reflecting the intuition that
-          they have no 'global' meaning.
-        </p>
-        <section id="shared_blank_nodes" class="informative">
-          <h3>Shared blank nodes (Informative)</h3>
-          <p> The semantics for blank nodes are stated in terms of the truth of a graph. However, when two (or more) graphs share a blank node, their meaning is not fully captured by treating them in isolation. For example, consider the overlapping graphs</p>
-          <p><img src="RDF12SemanticsDiagrams/example5.svg" alt="Overlapping Graphs" style="max-width: 100%"></p>
-          <p> and a simple interpretation <em>I</em> over the universe {Alice, Bob, Monica, Ruth} with:<br>
-            <em>I(<code>ex:Alice</code>)=Alice</em>, <em>I(<code>ex:Bob</code>)=Bob</em>, <em>IEXT(I(<code>ex:hasChild</code>))={&lt;Alice,Monica&gt;,&lt;Bob,Ruth&gt; }</em><br>
-          </p>
-          <p>Each of the inner graphs is true under this interpretation,
-            but the two of them together is not,
-            because the three-node graph says that Alice and Bob have a child together.
-            In order to capture the full meaning of graphs sharing a blank node,
-            it is necessary to consider the union graph containing all the triples
-            which contain the blank node.
-          </p>
-          <p class="technote"> RDF graphs can be viewed as conjunctions of simple atomic sentences in first-order logic,
-            where blank nodes are free variables which are understood to be existential.
-            Taking the union of two graphs is then analogous to syntactic conjunction in this syntax.
-            RDF syntax has no explicit variable-binding quantifiers, so the truth conditions for any RDF graph
-            treat the free variables in that graph as existentially quantified in that graph.
-            Taking the union of graphs which share a blank node changes the implied quantifier scopes.
-          </p>
-        </section>
-      </section>
-      <!-- commented out, to be removed later
-        <section id="intuitions" class="informative">
-          <h3>Intuitive summary (Informative)</h3>
-        
-          <p>An RDF graph is true exactly when:</p>
-          <p>1. the IRIs and literals in subject or object position in the graph all refer to things,</p><p>2. there is some way to interpret all the blank nodes in the graph as referring to things,</p><p>3. the IRIs in property position refer to binary relationships,</p><p>4. and under these interpretations, each triple S P O in the graph asserts that the thing referred to as S, and the thing referred to as O, do in fact stand in the relationship referred to by P.</p>
-        </section>
-        -->
-      <section id="simpleentailment">
-        <h2>Simple Entailment</h2>
-        <p>Following standard terminology, we say that <em>I</em> (simply) <dfn>satisfies</dfn>
-          <em>E</em> when <em>I(E)=true</em>, that <em>E</em> is (simply) <dfn>satisfiable</dfn>
-          when a simple interpretation exists which <a>satisfies</a> it,
-          otherwise (simply) <dfn>unsatisfiable</dfn>,
-          and that a graph <em>G</em> simply <dfn  id="dfn-entail" data-cite="RDF12-CONCEPTS#dfn-entailment" data-lt="entail" data-local-lt="simple entailment|entailment">entails</dfn>
-          a graph <em>E</em> when every interpretation which <a>satisfies</a> <em>G</em> also satisfies <em>E</em>.
-          If two graphs <em>E</em> and <em>F</em> each entail the other then they are logically <dfn id="dfn-equivalent" data-cite="RDF12-CONCEPTS#dfn-equivalence">equivalent</dfn>.
-          If there are no (simple) interpretations that satisfy a graph then that graph is 
-          <dfn id="dfn-inconsistent" data-cite="RDF12-CONCEPTS#dfn-inconsistent">inconsistent</dfn>.
-        </p>
-        <p>In later sections these notions will be adapted to other classes of interpretations,
-          but throughout this section 'entailment' should be interpreted as meaning simple entailment.
-        </p>
-        <p class="technote">We do not define a notion of entailment between sets of graphs.
-          To determine whether a set of graphs entails a graph,
-          the graphs in the set must first be combined into one graph,
-          either by taking the union or the merge of the graphs.
-          Unions preserve the common meaning of shared blank nodes,
-          while merging effectively ignores any sharing of blank nodes.
-          Merging the set of graphs produces the same definition of entailment by a set
-          that was defined in the 2004 RDF 1.0 specification.
-        </p>
-        <p>
-          Any process which constructs a graph <em>E</em> from
-          some other graph <em>S</em> is (simply) <dfn>valid</dfn> if <em>S</em>
-          <a>simply entails</a> <em>E</em> in every case,
-          otherwise <dfn class="no-export lint-ignore">invalid</dfn>
-          <span id="dfn-invalid.x">
-            <!-- refer to RDF Concepts term -->
-          </span>
-          .
-        </p>
-        <p>The fact that an inference is valid should not be understood as meaning
-          that any RDF application is obliged or required to make the inference.
-          Similarly, the logical invalidity of some RDF transformation or process
-          does not mean that the process is incorrect or prohibited.
-          Nothing in this specification requires or prohibits any particular operations on RDF graphs or sources.
-          Entailment and validity are concerned solely with establishing the conditions
-          on such operations which guarantee the preservation of truth.
-          While logically invalid processes, which do not follow valid entailments,
-          are not prohibited, users should be aware that they may be at risk of
-          introducing falsehoods into true RDF data.
-          Nevertheless, particular uses of logically invalid processes may be justified
-          and appropriate for data processing under circumstances where truth can be
-          ensured by other means.
-        </p>
-        <p>Entailment refers only to the truth of RDF graphs,
-          not to their suitability for any other purpose.
-          It is possible for an RDF graph to be fitted for a given purpose and yet validly entail
-          another graph which is not appropriate for the same purpose.
-          An example is the RDF test cases manifest [[?RDF-TESTCASES]] which is provided as an
-          RDF document for user convenience.
-          This document lists examples of correct entailments by describing their
-          antecedents and conclusions.
-          Considered as an RDF graph, the manifest <a>simply entails</a> a <a>subgraph</a>
-          which omits the antecedents,
-          and would therefore be incorrect if used as a test case manifest.
-          This is not a violation of the RDF semantic rules, but it shows that the property of
-          <em>"being a correct RDF test case manifest"</em>
-          is not preserved under RDF entailment,
-          and therefore cannot be described as an RDF <a>semantic extension</a>.
-          Such entailment-risky uses of RDF should be restricted to cases,
-          as here, where it is obvious to all parties what the intended special restrictions on entailment are,
-          in contrast with the more normal case of using RDF for the open publication of data on the Web.
-        </p>
-      </section>
-      <section id="simple_entailment_properties" class="informative">
-        <h3>Properties of simple entailment (Informative)</h3>
-        <p>The properties described here apply only to simple entailment,
-          not to extended notions of entailment introduced in later sections.
-          Proofs are given in <a href="#proofs" class="sectionRef"></a>.
-        </p>
-        <p class="fact">Every graph is simply <a>satisfiable</a>.</p>
-        <p>This does not always hold for extended notions of interpretation.
-          For example, a graph containing an <a>ill-typed</a> literal is <a>D-unsatisfiable</a>.
-        </p>
-        <p>The following <dfn>interpolation</dfn> <strong>lemma</strong> </p>
-        <p class="fact"><em>G</em> <a>simply entails</a> a graph <em>E</em> if and only if a <a>subgraph</a> of <em>G</em> is an instance of <em>E</em>.</p>
-        <p>completely characterizes simple entailment in syntactic
-          terms. To detect whether one RDF graph <a>simply entails</a> another, check that
-          there is some instance of the entailed graph which is a subset of the first graph.
-        </p>
-        <p class="technote">This is clearly decidable, but it is also difficult to determine in general,
-          since one can encode the NP-hard <a>subgraph</a> problem (detecting whether
-          one mathematical graph is a subgraph of another) as detecting simple entailment between RDF graphs.
-          This construction (due to Jeremy Carroll) uses graphs all of whose nodes are blank nodes.
-          The complexity of checking simple entailment is reduced by having fewer blank nodes in the conclusion <em>E</em>.
-          When <em>E</em> is a <a>ground</a> graph, it is simply a matter of checking the subset relationship on sets of triples.
-        </p>
-        <p><a>Interpolation</a> has a number of direct consequences, for example:</p>
-        <p class="fact">
-          The <a>empty graph</a> is simply entailed by
-          any graph, and does not simply entail any graph except itself.
-          <!-- <a href="#emptygraphlemmaprf" class="termref">[Proof]</a> -->
-        </p>
-        <p class="fact">
-          A graph <a>simply entails</a> all its subgraphs.
-          <!-- <a href="#subglemprf" class="termref">[Proof]</a> -->
-        </p>
-        <p class="fact">
-          A graph
-          is simply entailed by any of its <a>instance</a>s.
-          <!-- <a href="#instlemprf" class="termref"> [Proof]</a> -->
-        </p>
-        <p class="fact"> If
-          <em>E</em> is a <a>lean</a> graph and <em>E'</em> is a <a>proper instance</a> of <em>E</em>, then <em>E</em> does
-          not simply entail E'.
-        </p>
-        <p class="fact">
-          If <em>S</em> is a <a>subgraph</a> of <em>S'</em> and <em>S</em> <a>simply entails</a> <em>E</em>, then <em>S'</em> <a>simply entails</a> <em>E</em>.
-          <!-- <a href="#monotonicitylemmaprf" class="termref"> [Proof]</a> -->
-        </p>
-        <p class="fact">
-          If <em>S</em> entails a finite graph <em>E</em>, then some finite subset <em>S'</em> of <em>S</em> entails <em>E</em>.
-          <!-- <a href="#compactlemmaprf" class="termref"> [Proof]</a> -->
-        </p>
-        <p>The property just above is called <em>compactness</em> - RDF is compact.
-          As RDF graphs can be infinite, this is sometimes important.
-        </p>
-        <p class="fact"> If <em>E</em> contains an IRI which does not occur anywhere in <em>S</em>,
-          then <em>S</em> does not simply entail <em>E</em>.
-        </p>
-      </section>
+  </section>
+
+  <!-- commented out, to be removed later
+  <section id="intuitions" class="informative">
+    <h3>Intuitive summary (Informative)</h3>
+
+    <p>An RDF graph is true exactly when:</p>
+    <p>1. the IRIs and literals in subject or object position in the graph all refer to things,</p><p>2. there is some way to interpret all the blank nodes in the graph as referring to things,</p><p>3. the IRIs in property position refer to binary relationships,</p><p>4. and under these interpretations, each triple S P O in the graph asserts that the thing referred to as S, and the thing referred to as O, do in fact stand in the relationship referred to by P.</p>
+  </section>
+  -->
+
+  <section id="simpleentailment">
+    <h2>Simple Entailment</h2>
+
+    <p>Following standard terminology, we say that I (simply) <dfn>satisfies</dfn>
+      E when I(E)=true, that E is (simply) <dfn>satisfiable</dfn>
+      when a simple interpretation exists which <a>satisfies</a> it,
+      otherwise (simply) <dfn>unsatisfiable</dfn>,
+      and that a graph G simply <dfn  id="dfn-entail" data-cite="RDF12-CONCEPTS#dfn-entailment" data-lt="entail" data-local-lt="simple entailment|entailment">entails</dfn>
+      a graph E when every interpretation which <a>satisfies</a> G also satisfies E.
+      If two graphs E and F each entail the other then they are logically <dfn  id="dfn-equivalent" data-cite="RDF12-CONCEPTS#dfn-equivalence">equivalent</dfn>.
+      If there are no (simple) interpretations that satisfy a graph then that graph is 
+ <dfn id="dfn-inconsistent" data-cite="RDF12-CONCEPTS#dfn-inconsistent">inconsistent</dfn>.
+    </p>
+
+    <p>In later sections these notions will be adapted to other classes of interpretations,
+      but throughout this section 'entailment' should be interpreted as meaning simple entailment.</p>
+
+    <p class="technote">We do not define a notion of entailment between sets of graphs.
+      To determine whether a set of graphs entails a graph,
+      the graphs in the set must first be combined into one graph,
+      either by taking the union or the merge of the graphs.
+      Unions preserve the common meaning of shared blank nodes,
+      while merging effectively ignores any sharing of blank nodes.
+      Merging the set of graphs produces the same definition of entailment by a set
+      that was defined in the 2004 RDF 1.0 specification.</p>
+
+    <p>Any process which constructs a graph E from
+      some other graph S is (simply) <dfn>valid</dfn> if S
+      <a>simply entails</a> E in every case,
+      otherwise <dfn class="no-export lint-ignore">invalid</dfn><span id="dfn-invalid.x"><!-- refer to RDF Concepts term --></span>.</p>
+
+    <p>The fact that an inference is valid should not be understood as meaning
+      that any RDF application is obliged or required to make the inference.
+      Similarly, the logical invalidity of some RDF transformation or process
+      does not mean that the process is incorrect or prohibited.
+      Nothing in this specification requires or prohibits any particular operations on RDF graphs or sources.
+      Entailment and validity are concerned solely with establishing the conditions
+      on such operations which guarantee the preservation of truth.
+      While logically invalid processes, which do not follow valid entailments,
+      are not prohibited, users should be aware that they may be at risk of
+      introducing falsehoods into true RDF data.
+      Nevertheless, particular uses of logically invalid processes may be justified
+      and appropriate for data processing under circumstances where truth can be
+      ensured by other means.</p>
+
+    <p>Entailment refers only to the truth of RDF graphs,
+      not to their suitability for any other purpose.
+      It is possible for an RDF graph to be fitted for a given purpose and yet validly entail
+      another graph which is not appropriate for the same purpose.
+      An example is the RDF test cases manifest [[?RDF-TESTCASES]] which is provided as an
+      RDF document for user convenience.
+      This document lists examples of correct entailments by describing their
+      antecedents and conclusions.
+      Considered as an RDF graph, the manifest <a>simply entails</a> a <a>subgraph</a>
+      which omits the antecedents,
+      and would therefore be incorrect if used as a test case manifest.
+      This is not a violation of the RDF semantic rules, but it shows that the property of
+      <em>"being a correct RDF test case manifest"</em>
+      is not preserved under RDF entailment,
+      and therefore cannot be described as an RDF <a>semantic extension</a>.
+      Such entailment-risky uses of RDF should be restricted to cases,
+      as here, where it is obvious to all parties what the intended special restrictions on entailment are,
+      in contrast with the more normal case of using RDF for the open publication of data on the Web.</p>
+
+  </section>
+
+  <section id="simple_entailment_properties" class="informative">
+    <h3>Properties of simple entailment (Informative)</h3>
+
+    <p>The properties described here apply only to simple entailment,
+      not to extended notions of entailment introduced in later sections.
+      Proofs are given in <a href="#proofs" class="sectionRef"></a>.</p>
+
+    <p class="fact">Every graph is simply <a>satisfiable</a>.</p>
+
+    <p>This does not always hold for extended notions of interpretation.
+      For example, a graph containing an <a>ill-typed</a> literal is <a>D-unsatisfiable</a>.</p>
+
+    <p>The following <dfn>interpolation</dfn> <strong>lemma</strong> </p>
+
+    <p class="fact">G <a>simply entails</a> a graph E if and only if a <a>subgraph</a> of G is an instance of E.</p>
+
+    <p>completely characterizes simple entailment in syntactic
+      terms. To detect whether one RDF graph <a>simply entails</a> another, check that
+      there is some instance of the entailed graph which is a subset of the first graph.</p>
+
+    <p class="technote">This is clearly decidable, but it is also difficult to determine in general,
+      since one can encode the NP-hard <a>subgraph</a> problem (detecting whether
+      one mathematical graph is a subgraph of another) as detecting simple entailment between RDF graphs.
+      This construction (due to Jeremy Carroll) uses graphs all of whose nodes are blank nodes.
+      The complexity of checking simple entailment is reduced by having fewer blank nodes in the conclusion E.
+      When E is a <a>ground</a> graph, it is simply a matter of checking the subset relationship on sets of triples.</p>
+
+    <p><a>Interpolation</a> has a number of direct consequences, for example:</p>
+
+    <p class="fact"> The <a>empty graph</a> is simply entailed by
+      any graph, and does not simply entail any graph except itself.
+    <!-- <a href="#emptygraphlemmaprf" class="termref">[Proof]</a> -->
+    </p>
+    <p class="fact"> A graph <a>simply entails</a> all its subgraphs.
+    <!-- <a href="#subglemprf" class="termref">[Proof]</a> -->
+    </p>
+    <p class="fact"> A graph
+      is simply entailed by any of its <a>instance</a>s.
+    <!-- <a href="#instlemprf" class="termref"> [Proof]</a> -->
+    </p>
+    <p class="fact"> If
+      E is a <a>lean</a> graph and E' is a <a>proper instance</a> of E, then E does
+      not simply entail E'.
+    </p>
+
+    <p class="fact"> If S is a <a>subgraph</a> of S' and S <a>simply entails</a> E, then S' <a>simply entails</a> E.
+    <!-- <a href="#monotonicitylemmaprf" class="termref"> [Proof]</a> -->
+    </p>
+    <p class="fact">
+      If S entails a finite graph E, then some finite subset S' of S entails E.
+    <!-- <a href="#compactlemmaprf" class="termref"> [Proof]</a> -->
+    </p>
+    <p>The property just above is called <em>compactness</em> - RDF is compact.
+      As RDF graphs can be infinite, this is sometimes important.</p>
+
+    <p class="fact"> If E contains an IRI which does not occur anywhere in S,
+      then S does not simply entail E.</p>
+
+  </section>
+</section>
+
+<section id="skolemization" class="informative">
+  <h2>Skolemization (Informative)</h2>
+
+  <p><dfn class="no-export lint-ignore">Skolemization</dfn> is a transformation on RDF graphs
+    which eliminates blank nodes by replacing them with "new" IRIs,
+    which means IRIs which are coined for this purpose and are therefore guaranteed
+    to not occur in any other RDF graph (at the time of creation).
+    See <a data-cite="RDF12-CONCEPTS#section-skolemization">Section 3.5</a> of [[!RDF12-CONCEPTS]]
+    for a fuller discussion.</p>
+
+  <p>Suppose G is a graph containing blank nodes and sk is a skolemization mapping
+    from the blank nodes in G to the skolem IRIs which are substituted for them,
+    so that sk(G) is a skolemization of G.
+    Then the semantic relationship between them can be summarized as follows.</p>
+
+  <p class="fact">sk(G) <a>simply entails</a> G (since sk(G) is an instance of G.)</p>
+  <p class="fact">G does not simply entail sk(G) (since sk(G) contains IRIs not in G.) </p>
+  <p class="fact">For any graph H, if sk(G) <a>simply entails</a> H then there is a graph H' such that G entails H' and H=sk(H') . </p>
+  <p class="fact">For any graph H which does not contain any of the "new" IRIs introduced into sk(G),
+    sk(G) <a>simply entails</a> H if and only if G <a>simply entails</a> H.</p>
+
+  <p>The second property means that a graph is not logically <a>equivalent</a> to its skolemization.
+    Nevertheless, they are in a strong sense almost interchangeable, as shown the next two properties. The third property means that even when conclusions are drawn from the skolemized graph which do contain the new vocabulary, these will exactly mirror what could have been derived from the original graph with the original blank nodes in place. The replacement of blank nodes by IRIs does not effectively alter what can be validly derived from the graph, other than by giving new names to what were formerly anonymous entities. The fourth property, which is a consequence of the third, clearly shows that in some sense  a skolemization of G can "stand in for" G as far as entailments are concerned. Using sk(G) instead of G will not affect any entailments which do not involve the new skolem vocabulary.  </p>
+
+</section>
+
+<section id="datatypes">
+  <h2>Literals and datatypes</h2>
+
+  <p class="changenote">In the 2004 RDF 1.0 specification,
+    datatype D-entailment was defined as a <a>semantic extension</a> of RDFS-entailment.
+    Here it is defined as a direct extension to basic RDF.
+    This is more in conformity with actual usage,
+    where RDF with datatypes is widely used without the RDFS vocabulary.
+    If there is a need to distinguish this from the 2004 RDF 1.0 terminology,
+    the longer phrasing "simple D-entailment" or "simple datatype entailment"
+    should be used rather than "D-entailment".</p>
+
+  <p>Datatypes are <a>identified</a> by IRIs.
+    Interpretations will vary according to which IRIs are recognized as denoting datatypes.
+    We describe this using a parameter D on simple interpretations,
+    where D is the set of <dfn data-local-lt="recognized">recognize</dfn><em><strong>d</strong></em> datatype IRIs.</p>
+
+  <p class="changenote">The previous version of this specification defined the parameter D
+    as a <a>datatype map</a> from IRIs to datatypes,
+    i.e. as a restricted kind of interpretation mapping.
+    As the current semantics presumes that a recognized IRI identifies a unique datatype,
+    this IRI-to-datatype mapping is globally unique and externally specified,
+    so we can think of D as either a set of IRIs or as a fixed <a>datatype map</a>.
+    Formally, the <dfn>datatype map</dfn> corresponding to the set D is the
+    restriction of a <a>D-interpretation</a> to the set D.
+    Semantic extensions which are stated in terms of conditions on <a>datatype maps</a>
+    can be interpreted as applying to this mapping.</p>
+
+  <p>The exact mechanism by which an IRI <a>identifies</a> a datatype is considered to be
+    external to the semantics, but the semantics presumes that a recognized IRI <a>identifies</a>
+    a unique datatype wherever it occurs.
+    RDF processors which are not able to determine which datatype is identified by an IRI
+    cannot <a>recognize</a> that IRI,
+    and should treat any literals with that IRI as their datatype IRI as unknown names.</p>
+
+  <p>RDF literals and datatypes are fully described in
+    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Section 5</a> of [[!RDF12-CONCEPTS]].
+    In summary: with one exception, RDF literals combine a string and an IRI <a data-lt="identify">identifing</a> a datatype.
+    The exception is <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
+    which have two syntactic components, a string and a language tag,
+    and are assigned the type <code>rdf:langString</code>.
+    A datatype is understood to define a partial mapping, 
+    called the
+    <span id="dfn-lexical-to-value-mapping"><!-- refer to RDF Concepts term --></span>
+    <dfn data-cite="RDF12-CONCEPTS#dfn-lexical-to-value-mapping">lexical-to-value mapping</dfn>,
+    from a lexical space (a set of character strings) to values.
+    The function <dfn>L2V</dfn> maps datatypes to their lexical-to-value mapping.
+    A literal with datatype d <a>denotes</a> the value obtained by applying this mapping
+    to the character string sss: L2V(d)(sss).
+    If the literal string is not in the lexical space,
+    so that the lexical-to-value mapping gives no value for the literal string,
+    then the literal has no referent.
+    The <dfn>value space</dfn> of a datatype is the range of the <a>lexical-to-value mapping</a>.
+    Every literal with that type either <a>denotes</a> a value in the value space of the type,
+    or fails to denote at all.
+    An  <dfn>ill-typed</dfn> literal is one whose datatype IRI is <a>recognized</a>,
+    but whose character string is assigned no value by the <a>lexical-to-value mapping</a>
+    for that datatype.</p>
+
+  <p>RDF processors are not required to <a>recognize</a> any datatype IRIs other than
+    <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
+    and <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>,
+    but when IRIs listed in 
+    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Section 5</a> of [[!RDF12-CONCEPTS]]
+    are <a>recognized</a>, they MUST be interpreted as described there, and when the IRI <code>rdf:PlainLiteral</code> is <a>recognized</a>, it MUST be interpreted to denote the datatype defined in [[!RDF-PLAIN-LITERAL]]. RDF processors MAY recognize other datatype IRIs, but when other datatype IRIs are <a>recognized</a>, the mapping between the datatype IRI and the datatype it <a>denotes</a> MUST be specified unambiguously, and MUST be fixed during all RDF transformations or manipulations. In practice, this can be achieved by the IRI linking to an external specification of the datatype which describes both the components of the datatype itself and the fact that the IRI identifies the datatype, thereby fixing a value of the <a>datatype map</a> of this IRI.</p>
+
+  <p>Literals with <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
+    as their datatype are an exceptional case which are given a special treatment.
+    The IRI <code>rdf:langString</code> is classified as a datatype IRI,
+    and interpreted to denote a datatype, even though no <a>L2V</a> mapping is defined for it.
+    The <a>value space</a> of <code>rdf:langString</code> is the set of all pairs of a string with a language tag.
+    The semantics of literals with this as their type are given below.</p>
+
+  <p>RDF allows any IRI to be used in a literal,
+    even when it is not <a>recognized</a> as referring to a datatype.
+    Literals with such an "unknown" datatype IRI,
+    which is not in the set of <a>recognized</a> datatypes,
+    SHOULD NOT be treated as errors, although RDF applications MAY issue a warning.
+    Such literals SHOULD be treated like IRIs and assumed to denote some thing in the universe IR.
+    RDF processors which do not <a>recognize</a> a datatype IRI will not be able
+    to detect some entailments which are visible to one which does.
+    For example, the fact that</p>
+
+  <p><code>ex:a ex:p "20.0000"^^xsd:decimal .</code></p>
+  <p>entails</p>
+  <p><code>ex:a ex:p "20.0"^^xsd:decimal .</code></p>
+
+  <p>will not be visible to a processor which does not <a>recognize</a> the datatype IRI <code>xsd:decimal</code>.</p>
+
+  <section id="D_interpretations">
+    <h2>D-interpretations</h2>
+
+    <p>Let D be a set of IRIs <a>identify</a>ing datatypes.
+      A  <strong>(simple)</strong> <dfn>D-interpretation</dfn> is a <a>simple interpretation</a>
+      which satisfies the following conditions:</p>
+
+    <table>
+      <caption>Semantic conditions for literals.</caption>
+      <tbody>
+        <tr><td class="semantictable">If <code>rdf:langString</code> is in D,
+          then for every language-tagged string E with lexical form sss and language tag ttt,
+          IL(E)= &lt; sss, ttt' &gt;, where ttt' is ttt converted to lower case using US-ASCII rules</td></tr>
+
+        <tr><td class="semantictable">For every other IRI aaa in D,
+          I(aaa) is the datatype identified by aaa, and for every literal
+          "sss"^^aaa, IL("sss"^^aaa) = L2V(I(aaa))(sss)</td></tr>
+     </tbody>
+   </table>
+
+   <p>If the literal is <a>ill-typed</a> then the L2V(I(aaa)) mapping has no value,
+     and so the literal cannot denote anything.
+     In this case, any triple containing the literal must be false.
+     Thus, any triple, and hence any graph, containing an <a>ill-typed</a> literal will be
+     <a>D-unsatisfiable</a>, i.e. false in every D-interpretation.
+     This applies only to literals typed with recognized datatype IRIs in D;
+     literals with an unrecognized type IRI are not <a>ill-typed</a> and cannot give rise to
+     a <a>D-unsatisfiable</a> graph.</p>
+
+    <p>The special datatype <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
+      has no <a>ill-typed</a> literals.
+      Any syntactically legal literal with this type will denote a value in every
+      D-interpretation where D includes <code>rdf:langString</code>.
+      The only ill-typed literals of type <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>
+      are those containing a Unicode code point which does not match
+      the <a data-cite="XML11#NT-Char"><em>Char</em> production</a> in [[XML11]].
+      Such strings cannot be written in an XML-compatible surface syntax.</p>
+
+    <p class="changenote">In the 2004 RDF 1.0 specification,
+      ill-typed literals were required to denote a value in IR,
+      and <a>D-unsatisfiability</a> could be recognized only by using the RDFS semantics.</p>
+
+
+  </section>
+
+  <section id="D_entailment">
+    <h3>Datatype entailment</h3>
+
+    <p>A graph is (simply) <dfn class="no-export lint-ignore">D-satisfiable</dfn> or
+      <dfn class="no-export lint-ignore">satisfiable recognizing D</dfn> when it has the value true
+      in some D-interpretation, and a graph S (simply) <dfn>D-entails</dfn> or
+      <dfn>entails recognizing D</dfn> a graph G when every D-interpretation which
+      <a>satisfies</a> S also D-satisfies G.</p>
+
+    <p> Unlike the case with <a>simple interpretation</a>s,
+      it is possible for a graph to have no satisfying D-interpretations
+       i.e. to be <dfn class="no-export lint-ignore" data-lt="D-unsatisfiability">D-unsatisfiable</dfn>.
+       RDF processors MAY treat an unsatisfiable graph as signaling an error condition,
+       but this is not required.</p>
+
+    <p> A <a>D-unsatisfiable</a> graph <a>D-entails</a> any graph.</p>
+
+    <p class="technote">The fact that an <a>unsatisfiable</a> statement entails any other statement
+      has been known since antiquity.
+      It is called the principle of <em>ex falso quodlibet</em>.
+      It should not be interpreted to mean that it is necessary,
+      or even permissible, to actually draw any conclusion from an <a>unsatisfiable</a> graph.</p>
+
+    <p>In all of this language, 'D' is being used as a parameter to represent some set of datatype IRIs,
+      and different D sets will yield different notions of satisfiability and entailment.
+      The more datatypes are <a>recognized</a>, the stronger is the entailment,
+      so that if D &subset; E and S E-entails G then S must <a>D-entail</a> G.
+      Simple entailment is {&nbsp;}-entailment, i.e. D-entailment when D is the empty set,
+      so if S <a>D-entails</a> G  then S <a>simply entails</a> G. </p>
+
+    <section id="datatype_entailment_patterns" class="informative">
+      <h4>Patterns of datatype entailment (Informative)</h4>
+
+      <p>Unlike <a>simple entailment</a>, it is not possible to give a single syntactic criterion
+        to detect all D-entailments,
+        which can hold because of particular properties of the lexical-to-value mappings
+        of the <a>recognized</a> datatypes.
+        For example, if D contains <code>xsd:decimal</code> then</p>
+
+      <p><code>ex:a ex:p "25.0"^^xsd:decimal .</code></p>
+
+      <p>D-entails</p>
+
+      <p><code>ex:a ex:p "25"^^xsd:decimal .</code></p>
+
+      <p>In general, any triple containing a literal with a <a>recognized</a>
+        datatype IRI <a>D-entails</a> another literal when the lexical strings of
+        the literals map to the same value under the lexical-to-value map of the datatype.
+        If two different datatypes in D map lexical strings to a common value,
+        then a triple containing a literal typed with one datatype may <a>D-entail</a>
+        another triple containing a literal typed with a different datatype.
+        For example, <code>"25"^^xsd:integer</code> and <code>"25.0"^^xsd:decimal</code>
+        have the same value, so the above also <a>D-entails</a></p>
+
+      <p><code>ex:a ex:p "25"^^xsd:integer .</code></p>
+
+      <p>when D also contains <code>xsd:integer</code>.</p>
+
+      <p>(There is a W3C Note [[SWBP-XSCH-DATATYPES]] containing a long
+        <a data-cite="SWBP-XSCH-DATATYPES#sec-values">discussion</a> of literal values.)</p>
+
+      <p><a>Ill-typed</a> literals are the only way in which a graph can be simply <a>D-unsatisfiable</a>,
+        but datatypes can give rise to a variety of other <a>unsatisfiable</a> graphs
+        when combined with the RDFS vocabulary, defined later.</p>
     </section>
-    <section id="skolemization" class="informative">
-      <h2>Skolemization (Informative)</h2>
-      <p><dfn class="no-export lint-ignore">Skolemization</dfn> is a transformation on RDF graphs
-        which eliminates blank nodes by replacing them with "new" IRIs,
-        which means IRIs which are coined for this purpose and are therefore guaranteed
-        to not occur in any other RDF graph (at the time of creation).
-        See <a data-cite="RDF12-CONCEPTS#section-skolemization">Section 3.5</a> of [[!RDF12-CONCEPTS]]
-        for a fuller discussion.
-      </p>
-      <p>Suppose <em>G</em> is a graph containing blank nodes and sk is a skolemization mapping
-        from the blank nodes in <em>G</em> to the skolem IRIs which are substituted for them,
-        so that <em>sk(G)</em> is a skolemization of <em>G</em>.
-        Then the semantic relationship between them can be summarized as follows.
-      </p>
-      <p class="fact"><em>sk(G)</em> <a>simply entails</a> <em>G</em> (since <em>sk(G)</em> is an instance of <em>G</em>.)</p>
-      <p class="fact"><em>G</em> does not simply entail <em>sk(G)</em> (since <em>sk(G)</em> contains IRIs not in <em>G</em>.) </p>
-      <p class="fact">For any graph <em>H</em>, if <em>sk(G)</em> <a>simply entails</a> <em>H</em> then there is a graph H' such that <em>G</em> entails <em>H'</em> and <em>H=sk(H')</em>.</p>
-      <p class="fact">For any graph <em>H</em> which does not contain any of the "new" IRIs introduced into <em>sk(G)</em>,
-        <em>sk(G)</em> <a>simply entails</a> <em>H</em> if and only if <em>G</em> <a>simply entails</a> <em>H</em>.
-      </p>
-      <p>The second property means that a graph is not logically <a>equivalent</a> to its skolemization.
-        Nevertheless, they are in a strong sense almost interchangeable, as shown the next two properties. The third property means that even when conclusions are drawn from the skolemized graph which do contain the new vocabulary, these will exactly mirror what could have been derived from the original graph with the original blank nodes in place. The replacement of blank nodes by IRIs does not effectively alter what can be validly derived from the graph, other than by giving new names to what were formerly anonymous entities. The fourth property, which is a consequence of the third, clearly shows that in some sense  a skolemization of <em>G</em> can "stand in for" <em>G</em> as far as entailments are concerned. Using <em>sk(G)</em> instead of <em>G</em> will not affect any entailments which do not involve the new skolem vocabulary.  
-      </p>
-    </section>
-    <section id="datatypes">
-      <h2>Literals and datatypes</h2>
-      <p class="changenote">In the 2004 RDF 1.0 specification,
-        datatype D-entailment was defined as a <a>semantic extension</a> of RDFS-entailment.
-        Here it is defined as a direct extension to basic RDF.
-        This is more in conformity with actual usage,
-        where RDF with datatypes is widely used without the RDFS vocabulary.
-        If there is a need to distinguish this from the 2004 RDF 1.0 terminology,
-        the longer phrasing "simple D-entailment" or "simple datatype entailment"
-        should be used rather than "D-entailment".
-      </p>
-      <p>Datatypes are <a>identified</a> by IRIs.
-        Interpretations will vary according to which IRIs are recognized as denoting datatypes.
-        We describe this using a parameter D on simple interpretations,
-        where D is the set of <dfn data-local-lt="recognized">recognize</dfn><em><strong>d</strong></em> datatype IRIs.
-      </p>
-      <p class="changenote">The previous version of this specification defined the parameter D
-        as a <a>datatype map</a> from IRIs to datatypes,
-        i.e. as a restricted kind of interpretation mapping.
-        As the current semantics presumes that a recognized IRI identifies a unique datatype,
-        this IRI-to-datatype mapping is globally unique and externally specified,
-        so we can think of D as either a set of IRIs or as a fixed <a>datatype map</a>.
-        Formally, the <dfn>datatype map</dfn> corresponding to the set D is the
-        restriction of a <a>D-interpretation</a> to the set D.
-        Semantic extensions which are stated in terms of conditions on <a>datatype maps</a>
-        can be interpreted as applying to this mapping.
-      </p>
-      <p>The exact mechanism by which an IRI <a>identifies</a> a datatype is considered to be
-        external to the semantics, but the semantics presumes that a recognized IRI <a>identifies</a>
-        a unique datatype wherever it occurs.
-        RDF processors which are not able to determine which datatype is identified by an IRI
-        cannot <a>recognize</a> that IRI,
-        and should treat any literals with that IRI as their datatype IRI as unknown names.
-      </p>
-      <p>
-        RDF literals and datatypes are fully described in
-        <a data-cite="RDF12-CONCEPTS#section-Datatypes">Section 5</a> of [[!RDF12-CONCEPTS]].
-        In summary: with one exception, RDF literals combine a string and an IRI <a data-lt="identify">identifing</a> a datatype.
-        The exception is <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
-        which have two syntactic components, a string and a language tag,
-        and are assigned the type <code>rdf:langString</code>.
-        A datatype is understood to define a partial mapping, 
-        called the
-        <span id="dfn-lexical-to-value-mapping">
-          <!-- refer to RDF Concepts term -->
-        </span>
-        <dfn data-cite="RDF12-CONCEPTS#dfn-lexical-to-value-mapping">lexical-to-value mapping</dfn>,
-        from a lexical space (a set of character strings) to values.
-        The function <dfn>L2V</dfn> maps datatypes to their lexical-to-value mapping.
-        A literal with datatype d <a>denotes</a> the value obtained by applying this mapping
-        to the character string sss: L2V(d)(sss).
-        If the literal string is not in the lexical space,
-        so that the lexical-to-value mapping gives no value for the literal string,
-        then the literal has no referent.
-        The <dfn>value space</dfn> of a datatype is the range of the <a>lexical-to-value mapping</a>.
-        Every literal with that type either <a>denotes</a> a value in the value space of the type,
-        or fails to denote at all.
-        An  <dfn>ill-typed</dfn> literal is one whose datatype IRI is <a>recognized</a>,
-        but whose character string is assigned no value by the <a>lexical-to-value mapping</a>
-        for that datatype.
-      </p>
-      <p>RDF processors are not required to <a>recognize</a> any datatype IRIs other than
-        <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
-        and <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>,
-        but when IRIs listed in 
-        <a data-cite="RDF12-CONCEPTS#section-Datatypes">Section 5</a> of [[!RDF12-CONCEPTS]]
-        are <a>recognized</a>, they MUST be interpreted as described there, and when the IRI <code>rdf:PlainLiteral</code> is <a>recognized</a>, it MUST be interpreted to denote the datatype defined in [[!RDF-PLAIN-LITERAL]]. RDF processors MAY recognize other datatype IRIs, but when other datatype IRIs are <a>recognized</a>, the mapping between the datatype IRI and the datatype it <a>denotes</a> MUST be specified unambiguously, and MUST be fixed during all RDF transformations or manipulations. In practice, this can be achieved by the IRI linking to an external specification of the datatype which describes both the components of the datatype itself and the fact that the IRI identifies the datatype, thereby fixing a value of the <a>datatype map</a> of this IRI.
-      </p>
-      <p>Literals with <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
-        as their datatype are an exceptional case which are given a special treatment.
-        The IRI <code>rdf:langString</code> is classified as a datatype IRI,
-        and interpreted to denote a datatype, even though no <a>L2V</a> mapping is defined for it.
-        The <a>value space</a> of <code>rdf:langString</code> is the set of all pairs of a string with a language tag.
-        The semantics of literals with this as their type are given below.
-      </p>
-      <p>RDF allows any IRI to be used in a literal,
-        even when it is not <a>recognized</a> as referring to a datatype.
-        Literals with such an "unknown" datatype IRI,
-        which is not in the set of <a>recognized</a> datatypes,
-        SHOULD NOT be treated as errors, although RDF applications MAY issue a warning.
-        Such literals SHOULD be treated like IRIs and assumed to denote some thing in the universe IR.
-        RDF processors which do not <a>recognize</a> a datatype IRI will not be able
-        to detect some entailments which are visible to one which does.
-        For example, the fact that
-      </p>
-      <p><code>ex:a ex:p "20.0000"^^xsd:decimal .</code></p>
-      <p>entails</p>
-      <p><code>ex:a ex:p "20.0"^^xsd:decimal .</code></p>
-      <p>will not be visible to a processor which does not <a>recognize</a> the datatype IRI <code>xsd:decimal</code>.</p>
-      <section id="D_interpretations">
-        <h2>D-interpretations</h2>
-        <p>Let D be a set of IRIs <a>identify</a>ing datatypes.
-          A  <strong>(simple)</strong> <dfn>D-interpretation</dfn> is a <a>simple interpretation</a>
-          which satisfies the following conditions:
-        </p>
-        <section class="notoc">
-          <h6 class="defcap">Semantic Conditions for Literals</h6>
-          <div class="semantictable">
-            <p>If <code>rdf:langString</code> is in <em>D</em>, then for every language-tagged string <em>E</em> 
-              with lexical form <em>sss</em> and language tag <em>ttt</em>, 
-              <em>IL(E) = &lt; sss, ttt' &gt;</em>, where <em>ttt'</em> is <em>ttt</em> converted to lowercase 
-              using US-ASCII rules.
-            </p>
-            <span class="space"></span>
-            <p>For every other IRI <em>aaa</em> in <em>D</em>, <em>I(aaa)</em> is the datatype identified by 
-              <em>aaa</em>, and for every literal <code>"sss"^^aaa</code>, 
-              <em>IL("sss"^^aaa) = L2V(I(aaa))(sss)</em>.
-            </p>
-          </div>
-        </section>
-        <p>If the literal is <a>ill-typed</a> then the L2V(I(aaa)) mapping has no value,
-          and so the literal cannot denote anything.
-          In this case, any triple containing the literal must be false.
-          Thus, any triple, and hence any graph, containing an <a>ill-typed</a> literal will be
-          <a>D-unsatisfiable</a>, i.e. false in every D-interpretation.
-          This applies only to literals typed with recognized datatype IRIs in D;
-          literals with an unrecognized type IRI are not <a>ill-typed</a> and cannot give rise to
-          a <a>D-unsatisfiable</a> graph.
-        </p>
-        <p>The special datatype <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
-          has no <a>ill-typed</a> literals.
-          Any syntactically legal literal with this type will denote a value in every
-          D-interpretation where D includes <code>rdf:langString</code>.
-          The only ill-typed literals of type <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>
-          are those containing a Unicode code point which does not match
-          the <a data-cite="XML11#NT-Char"><em>Char</em> production</a> in [[XML11]].
-          Such strings cannot be written in an XML-compatible surface syntax.
-        </p>
-        <p class="changenote">In the 2004 RDF 1.0 specification,
-          ill-typed literals were required to denote a value in IR,
-          and <a>D-unsatisfiability</a> could be recognized only by using the RDFS semantics.
-        </p>
-      </section>
-      <section id="D_entailment">
-        <h3>Datatype entailment</h3>
-        <p>A graph is (simply) <dfn class="no-export lint-ignore">D-satisfiable</dfn> or
-          <dfn class="no-export lint-ignore">satisfiable recognizing D</dfn> when it has the value true
-          in some D-interpretation, and a graph <em>S</em> (simply) <dfn>D-entails</dfn> or
-          <dfn>entails recognizing D</dfn> a graph <em>G</em> when every D-interpretation which
-          <a>satisfies</a> <em>S</em> also D-satisfies <em>G</em>.
-        </p>
-        <p> Unlike the case with <a>simple interpretation</a>s,
-          it is possible for a graph to have no satisfying D-interpretations
-          i.e. to be <dfn class="no-export lint-ignore" data-lt="D-unsatisfiability">D-unsatisfiable</dfn>.
-          RDF processors MAY treat an unsatisfiable graph as signaling an error condition,
-          but this is not required.
-        </p>
-        <p> A <a>D-unsatisfiable</a> graph <a>D-entails</a> any graph.</p>
-        <p class="technote">The fact that an <a>unsatisfiable</a> statement entails any other statement
-          has been known since antiquity.
-          It is called the principle of <em>ex falso quodlibet</em>.
-          It should not be interpreted to mean that it is necessary,
-          or even permissible, to actually draw any conclusion from an <a>unsatisfiable</a> graph.
-        </p>
-        <p>In all of this language, 'D' is being used as a parameter to represent some set of datatype IRIs,
-          and different D sets will yield different notions of satisfiability and entailment.
-          The more datatypes are <a>recognized</a>, the stronger is the entailment,
-          so that if D &subset; <em>E</em> and <em>S</em> E-entails <em>G</em> then <em>S</em> must <a>D-entail</a> <em>G</em>.
-          Simple entailment is {&nbsp;}-entailment, i.e. D-entailment when D is the empty set,
-          so if <em>S</em> <a>D-entails</a> <em>G</em> then <em>S</em> <a>simply entails</a> <em>G</em>. 
-        </p>
-        <section id="datatype_entailment_patterns" class="informative">
-          <h4>Patterns of datatype entailment (Informative)</h4>
-          <p>Unlike <a>simple entailment</a>, it is not possible to give a single syntactic criterion
-            to detect all D-entailments,
-            which can hold because of particular properties of the lexical-to-value mappings
-            of the <a>recognized</a> datatypes.
-            For example, if D contains <code>xsd:decimal</code> then
-          </p>
-          <p><code>ex:a ex:p "25.0"^^xsd:decimal .</code></p>
-          <p>D-entails</p>
-          <p><code>ex:a ex:p "25"^^xsd:decimal .</code></p>
-          <p>In general, any triple containing a literal with a <a>recognized</a>
-            datatype IRI <a>D-entails</a> another literal when the lexical strings of
-            the literals map to the same value under the lexical-to-value map of the datatype.
-            If two different datatypes in D map lexical strings to a common value,
-            then a triple containing a literal typed with one datatype may <a>D-entail</a>
-            another triple containing a literal typed with a different datatype.
-            For example, <code>"25"^^xsd:integer</code> and <code>"25.0"^^xsd:decimal</code>
-            have the same value, so the above also <a>D-entails</a>
-          </p>
-          <p><code>ex:a ex:p "25"^^xsd:integer .</code></p>
-          <p>when D also contains <code>xsd:integer</code>.</p>
-          <p>(There is a W3C Note [[SWBP-XSCH-DATATYPES]] containing a long
-            <a data-cite="SWBP-XSCH-DATATYPES#sec-values">discussion</a> of literal values.)
-          </p>
-          <p><a>Ill-typed</a> literals are the only way in which a graph can be simply <a>D-unsatisfiable</a>,
-            but datatypes can give rise to a variety of other <a>unsatisfiable</a> graphs
-            when combined with the RDFS vocabulary, defined later.
-          </p>
-        </section>
-      </section>
-    </section>
-    <section id="rdf_d_interpretations">
-      <h2>RDF Interpretations</h2>
-      <p>RDF interpretations impose extra semantic conditions on <code>xsd:string</code>
-        and part of the infinite set of IRIs with the namespace prefix <code>rdf:</code> .
-      <section class="notoc">
-        <h6 class="defcap"><dfn>RDF vocabulary</dfn></h6>
-        <ul class="cols">
-          <li><code>rdf:type</code></li>
-          <li><code>rdf:subject</code></li>
-          <li><code>rdf:predicate</code></li>
-          <li><code>rdf:object</code></li>
-          <li><code>rdf:first</code></li>
-          <li><code>rdf:rest</code></li>
-          <li><code>rdf:value</code></li>
-          <li><code>rdf:nil</code></li>
-          <li><code>rdf:List</code></li>
-          <li><code>rdf:langString</code></li>
-          <li><code>rdf:Property</code></li>
-          <li><code>rdf:_1</code></li>
-          <li><code>rdf:_2</code></li>
-          <li><code>...</code></li>
-        </ul>
-      </section>
-      <p>An <dfn>RDF interpretation</dfn> <strong>recognizing D</strong> is a <a>D-interpretation</a> I
-        where D includes <code>rdf:langString</code> and <code>xsd:string</code>, and which satisfies:
-      </p>
-      <section class="notoc">
-        <h6 class="defcap">RDF Semantic Conditions</h6>
-        <div class="semantictable">
-          <p id="rdfsemcond1">
-            <em>x</em> is in <em>IP</em> if and only if &lt;<em>x</em>, <em>I(<code>rdf:Property</code>)</em>&gt; 
-            is in <em>IEXT(I(<code>rdf:type</code>))</em>.
-          </p>
-          <span class="space"></span>
-          <p id="rdfsemcond3">
-            For every IRI <em>aaa</em> in <em>D</em>, &lt;<em>x</em>, <em>I(aaa)</em>&gt; is in 
-            <em>IEXT(I(<code>rdf:type</code>))</em> if and only if <em>x</em> is in the 
-            <a>value space</a> of <em>I(aaa)</em>.
-          </p>
-        </div>
-      </section>
-      <p>and <a>satisfies</a> every triple in the following infinite set:</p>
-      <section class="notoc">
-        <h6 class="defcap">RDF Axioms</h6>
-        <div class="ruletable" id="RDF_axiomatic_triples">
-          <pre class="nohighlight">
-            rdf:type      rdf:type rdf:Property .
-            rdf:subject   rdf:type rdf:Property .
-            rdf:predicate rdf:type rdf:Property .
-            rdf:object    rdf:type rdf:Property .
-            rdf:first     rdf:type rdf:Property .
-            rdf:rest      rdf:type rdf:Property .
-            rdf:value     rdf:type rdf:Property .
-            rdf:nil       rdf:type rdf:List .
-            rdf:_1        rdf:type rdf:Property .
-            rdf:_2        rdf:type rdf:Property .
-            ...
-          </pre>
-        </div>
-      </section>
-      <p>RDF imposes no particular normative meanings on the rest of the RDF vocabulary.
-        <a href="#whatnot">Appendix D</a> describes the intended uses of some of this vocabulary.
-      </p>
-      <p>The datatype IRIs <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
-        and <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>
-        MUST be <a>recognized</a> by all RDF interpretations.
-      </p>
-      <p>Two other datatypes <a data-cite="RDF12-CONCEPTS#section-XMLLiteral"><code>rdf:XMLLiteral</code></a>
-        and <a data-cite="RDF12-CONCEPTS#section-html"><code>rdf:HTML</code></a> are defined in [[!RDF12-CONCEPTS]].
-        RDF-D interpretations MAY fail to <a>recognize</a> these datatypes.
-      </p>
-      <section id="rdf_entail">
-        <h3>RDF entailment</h3>
-        <p><em>S</em> <dfn>RDF entail</dfn><strong>s</strong> <em>E</em> <strong>recognizing D</strong>
-          when every <a>RDF interpretation</a> recognizing D which <a>satisfies</a>
-          <em>S</em> also satisfies <em>E</em>. When D is {<code>rdf:langString</code>, <code>xsd:string</code>}
-          then we simply say <em>S</em> <strong>RDF entails</strong> <em>E</em>.
-          <em>E</em> is <dfn>RDF unsatisfiable</dfn><strong> (recognizing D)</strong>
-          when it has no satisfying <a>RDF interpretation</a> (recognizing D).
-        </p>
-        <p>The properties of <a>simple entailment</a> described earlier do not all apply to <a>RDF entail</a>ment.
-          For example, all the RDF axioms are true in every <a>RDF interpretation</a>,
-          and so are <a>RDF entail</a>ed by the empty graph, contradicting <a>interpolation</a> for RDF entailment. 
-        </p>
-        <section id="rdf_entailment_patterns" class="informative">
-          <h4>Patterns of RDF entailment (Informative)</h4>
-          <p>The last semantic condition in the above table gives the following entailment pattern for <a>recognized</a> datatype IRIs:</p>
-          <table>
-            <caption>RDF entailment pattern.</caption>
-            <tbody>
-              <tr>
-                <th > </th>
-                <th ><strong>if <em>S</em> contains</strong></th>
-                <th ><strong>then <em>S</em> RDF entails, recognizing D</strong></th>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfD1</dfn></td>
-                <td class="othertable">   xxx aaa <code>"</code>sss<code>"^^</code>ddd <code>.</code> <br>
-                  for ddd in D
-                </td>
-                <td class="othertable">xxx aaa _:nnn <code>.</code><br>
-                  _:nnn <code>rdf:type</code> ddd <code>.</code>
-                </td>
-              </tr>
-            </tbody>
-          </table>
-          <p>Note, this is valid even when the literal is <a>ill-typed</a>, since an unsatisfiable graph entails any triple.</p>
-          <p>For example,</p>
-          <p><code>ex:a ex:p "123"^^xsd:integer .</code></p>
-          <p>RDF entails recognizing {<code>xsd:integer</code>}</p>
-          <pre class="nohighlight">
-            ex:a ex:p     _:x .
-            _:x  rdf:type xsd:integer .
-          </pre>
-          <p>The last semantic condition above also justifies the following entailment pattern:</p>
-          <table>
-            <tbody>
-              <tr>
-                <th> </th>
-                <th><strong>any S</strong></th>
-                <th><strong>then <em>S</em> RDF entails, recognizing D</strong></th>
-              </tr>
-              <tr>
-                <td class="othertable"><dfn>rdfD1a</dfn></td>
-                <td class="othertable">for ddd in D with non-empty value space</td>
-                <td class="othertable">_:nnn <code>rdf:type</code> ddd <code>.</code></td>
-              </tr>
-            </tbody>
-          </table>
-          <p>In addition, the first RDF semantic condition justifies the following entailment pattern:</p>
-          <table>
-            <tbody>
-              <tr>
-                <th></th>
-                <th><strong>if <em>S</em> contains</strong></th>
-                <th><strong>then <em>S</em> RDF entails, recognizing D</strong></th>
-              </tr>
-              <tr>
-                <td class="othertable"><dfn>rdfD2</dfn></td>
-                <td class="othertable">xxx aaa yyy <code>.</code></td>
-                <td class="othertable">aaa <code>rdf:type rdf:Property .</code> </td>
-              </tr>
-            </tbody>
-          </table>
-          <p>So that the above example also RDF entails</p>
-          <p><code>ex:p rdf:type rdf:Property .</code></p>
-          <p> recognizing {<code>xsd:integer</code>}.</p>
-          <p>Some datatypes support idiosyncratic entailment patterns which do not hold for other datatypes. For example,</p>
-          <pre class="nohighlight">
-            ex:a ex:p     "true"^^xsd:boolean .
-            ex:a ex:p     "false"^^xsd:boolean .
-            ex:v rdf:type xsd:boolean .
-          </pre>
-          <p>together RDF entail</p>
-          <p><code>ex:a ex:p ex:v .</code></p>
-          <p>recognizing {<code>xsd:boolean</code>}.</p>
-          <p>In addition, the semantic conditions on <a>value spaces</a> may produce other <a>unsatisfiable</a> graphs.
-            For example, when D contains <code>xsd:integer</code> and <code>xsd:boolean</code>,
-            then the following is <a>RDF unsatisfiable</a> recognizing D:
-          </p>
-          <pre class="nohighlight">
-            _:x rdf:type xsd:boolean .
-            _:x rdf:type xsd:integer .
-          </pre>
-        </section>
-      </section>
-    </section>
-    <section id="rdfs_interpretations">
-      <h2>RDFS Interpretations</h2>
-      <p>RDF Schema [[RDF12-SCHEMA]] extends RDF to a larger vocabulary with more complex semantic constraints:</p>
-      <section class="notoc">
-        <h6 class="defcap"><dfn>RDFS vocabulary</dfn></h6>
-        <div>
-          <p><code>rdfs:domain rdfs:range rdfs:Resource rdfs:Literal rdfs:Datatype rdfs:Class rdfs:subClassOf rdfs:subPropertyOf rdfs:member rdfs:Container rdfs:ContainerMembershipProperty rdfs:comment rdfs:seeAlso rdfs:isDefinedBy rdfs:label</code></p>
-        </div>
-      </section>
-      <p>(<code>rdfs:comment</code>,<code> rdfs:seeAlso</code>, <code>rdfs:isDefinedBy</code>
-        and <code>rdfs:label</code> are included here because some constraints which
-        apply to their use can be stated using <code>rdfs:domain</code>,<code> rdfs:range</code>
-        and <code>rdfs:subPropertyOf</code>. Other than this, the formal semantics does
-        not constrain their meanings.)
-      </p>
-      <p>It is convenient to state the RDFS semantics
-        in terms of a new semantic construct, a <dfn>class</dfn>, i.e. a resource which represents
-        a set of things in the universe which all have that class as a value of their
-        <code>rdf:type</code> property. <a>Class</a>es are defined to be things of type <code>rdfs:Class</code>,
-        and the set of all classes in an interpretation will be called IC.
-        The semantic conditions are stated in terms of a mapping ICEXT (for the <em>C</em>lass
-        <em>Ext</em>ension in I) from IC to the set of subsets of IR.
-      </p>
-      <p> A class may have an
-        empty class extension. Two different classes can have the same class extension.
-        The class extension of <code>rdfs:Class</code> contains the class <code>rdfs:Class</code>.
-      </p>
-      <p> An <dfn>RDFS interpretation</dfn> (<strong>recognizing D</strong>) is an <a>RDF interpretation</a> (recognizing D) I
-        which <a>satisfies</a> the semantic conditions in the following table, and all the triples in the subsequent table of RDFS axiomatic triples.
-      </p>
-      <section class="notoc" id="rdfs_semantic_conditions">
-        <h6 class="defcap">RDFS Semantic Conditions</h6>
-        <div class="semantictable">
-          <div id="rdfssemcond1">
-            <p><em>ICEXT(y)</em> is defined to be { <em>x</em> : &lt;<em>x, y</em>&gt; is in <em>IEXT(I(<code>rdf:type</code>))</em> }</p>
-            <p><em>IC</em> is defined to be <em>ICEXT(I(<code>rdfs:Class</code>))</em></p>
-            <p><em>LV</em> is defined to be <em>ICEXT(I(<code>rdfs:Literal</code>))</em></p>
-            <p><em>ICEXT(I(<code>rdfs:Resource</code>)) = IR</em></p>
-            <p><em>ICEXT(I(<code>rdf:langString</code>))</em> is the set {<em>I(E)</em> : <em>E</em> a language-tagged string }</p>
-            <p>For every other IRI <em>aaa</em> in <em>D</em>, <em>ICEXT(I(aaa))</em> is the <a>value space</a> of <em>I(aaa)</em></p>
-            <p>For every IRI <em>aaa</em> in <em>D</em>, <em>I(aaa)</em> is in <em>ICEXT(I(<code>rdfs:Datatype</code>))</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond2">
-            <p>If &lt;<em>x, y</em>&gt; is in <em>IEXT(I(<code>rdfs:domain</code>))</em> and &lt;<em>u, v</em>&gt; is in <em>IEXT(x)</em> then <em>u</em> is in <em>ICEXT(y)</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond3">
-            <p>If &lt;<em>x, y</em>&gt; is in <em>IEXT(I(<code>rdfs:range</code>))</em> and &lt;<em>u, v</em>&gt; is in <em>IEXT(x)</em> then <em>v</em> is in <em>ICEXT(y)</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond4">
-            <p><em>IEXT(I(<code>rdfs:subPropertyOf</code>))</em> is transitive and reflexive on <em>IP</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond5">
-            <p>If &lt;<em>x, y</em>&gt; is in <em>IEXT(I(<code>rdfs:subPropertyOf</code>))</em> then <em>x</em> and <em>y</em> are in <em>IP</em> and <em>IEXT(x)</em> is a subset of <em>IEXT(y)</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond6">
-            <p>If <em>x</em> is in <em>IC</em> then &lt;<em>x</em>, <em>I(<code>rdfs:Resource</code>)</em>&gt; is in <em>IEXT(I(<code>rdfs:subClassOf</code>))</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond8">
-            <p><em>IEXT(I(<code>rdfs:subClassOf</code>))</em> is transitive and reflexive on <em>IC</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond7">
-            <p>If &lt;<em>x, y</em>&gt; is in <em>IEXT(I(<code>rdfs:subClassOf</code>))</em> then <em>x</em> and <em>y</em> are in <em>IC</em> and <em>ICEXT(x)</em> is a subset of <em>ICEXT(y)</em></p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond9">
-            <p>If <em>x</em> is in <em>ICEXT(I(<code>rdfs:ContainerMembershipProperty</code>))</em> then:<br>
-              &lt;<em>x</em>, <em>I(<code>rdfs:member</code>)</em>&gt; is in <em>IEXT(I(<code>rdfs:subPropertyOf</code>))</em>
-            </p>
-          </div>
-          <span class="space"></span>
-          <div id="rdfssemcond10">
-            <p>If <em>x</em> is in <em>ICEXT(I(<code>rdfs:Datatype</code>))</em> then &lt;<em>x</em>, <em>I(<code>rdfs:Literal</code>)</em>&gt; is in <em>IEXT(I(<code>rdfs:subClassOf</code>))</em></p>
-          </div>
-        </div>
-      </section>
-      <section class="notoc" id="RDFS_axiomatic_triples">
-        <h6 class="defcap">RDFS Axiomatic Triples</h6>
-        <div class="ruletable">
-          <pre class="nohighlight">
-            rdf:type                         rdfs:domain        rdfs:Resource .
-            rdfs:domain                      rdfs:domain        rdf:Property .
-            rdfs:range                       rdfs:domain        rdf:Property .
-            rdfs:subPropertyOf               rdfs:domain        rdf:Property .
-            rdfs:subClassOf                  rdfs:domain        rdfs:Class .
-            rdf:subject                      rdfs:domain        rdf:Statement .
-            rdf:predicate                    rdfs:domain        rdf:Statement .
-            rdf:object                       rdfs:domain        rdf:Statement .
-            rdfs:member                      rdfs:domain        rdfs:Resource .
-            rdf:first                        rdfs:domain        rdf:List .
-            rdf:rest                         rdfs:domain        rdf:List .
-            rdfs:seeAlso                     rdfs:domain        rdfs:Resource .
-            rdfs:isDefinedBy                 rdfs:domain        rdfs:Resource .
-            rdfs:comment                     rdfs:domain        rdfs:Resource .
-            rdfs:label                       rdfs:domain        rdfs:Resource .
-            rdf:value                        rdfs:domain        rdfs:Resource .
-            
-            rdf:type                         rdfs:range         rdfs:Class .
-            rdfs:domain                      rdfs:range         rdfs:Class .
-            rdfs:range                       rdfs:range         rdfs:Class .
-            rdfs:subPropertyOf               rdfs:range         rdf:Property .
-            rdfs:subClassOf                  rdfs:range         rdfs:Class .
-            rdf:subject                      rdfs:range         rdfs:Resource .
-            rdf:predicate                    rdfs:range         rdfs:Resource .
-            rdf:object                       rdfs:range         rdfs:Resource .
-            rdfs:member                      rdfs:range         rdfs:Resource .
-            rdf:first                        rdfs:range         rdfs:Resource .
-            rdf:rest                         rdfs:range         rdf:List .
-            rdfs:seeAlso                     rdfs:range         rdfs:Resource .
-            rdfs:isDefinedBy                 rdfs:range         rdfs:Resource .
-            rdfs:comment                     rdfs:range         rdfs:Literal .
-            rdfs:label                       rdfs:range         rdfs:Literal .
-            rdf:value                        rdfs:range         rdfs:Resource .
-            
-            rdf:Alt                          rdfs:subClassOf    rdfs:Container .
-            rdf:Bag                          rdfs:subClassOf    rdfs:Container .
-            rdf:Seq                          rdfs:subClassOf    rdfs:Container .
-            rdfs:ContainerMembershipProperty rdfs:subClassOf    rdf:Property .
-            
-            rdfs:isDefinedBy                 rdfs:subPropertyOf rdfs:seeAlso .
-            
-            rdfs:Datatype                    rdfs:subClassOf    rdfs:Class .
-            
-            rdf:_1                           rdf:type           rdfs:ContainerMembershipProperty .
-            rdf:_1                           rdfs:domain        rdfs:Resource .
-            rdf:_1                           rdfs:range         rdfs:Resource .
-            rdf:_2                           rdf:type           rdfs:ContainerMembershipProperty .
-            rdf:_2                           rdfs:domain        rdfs:Resource .
-            rdf:_2                           rdfs:range         rdfs:Resource .
-            ...
-          </pre>
-        </div>
-      </section>
-      <p class="changenote">In the 2004 RDF 1.0 semantics, LV was defined as part of a simple interpretation structure,
-        and the definition given here was a constraint. 
-      </p>
-      <p>Since <em>I</em> is an <a>RDF interpretation</a>, the first condition implies that <em>IP
-        = ICEXT(I(<code>rdf:Property</code>))</em>.
-      </p>
-      <p>The semantic conditions on <a>RDF interpretation</a>s,
-        together with the RDFS conditions on ICEXT, mean that every <a>recognized</a> datatype
-        can be treated as a class whose extension is the <a>value space</a> of the datatype,
-        and every literal with that datatype either fails to denote, or <a>denotes</a> a value in that class.
-      </p>
-      <p>When using RDFS semantics, the referents of all <a>recognized</a> datatype IRIs can be considered
-        to be in the <a>class</a> <code>rdfs:Datatype</code>.
-      </p>
-      <p>The axioms and conditions listed above have some redundancy. For example, all but one
-        of the RDF axiomatic triples can be derived from the RDFS axiomatic triples
-        and the semantic conditions on ICEXT,<code> rdfs:domain</code> and <code>rdfs:range</code>. 
-      </p>
-      <p>Other triples which must be true in all RDFS interpretations
-        include the following. This is not a complete set.
-      </p>
-      <section class="notoc">
-        <h6 class="defcap">Some RDFS-Valid Triples</h6>
-        <div class="ruletable">
-          <pre class="nohighlight">
-            rdfs:Resource                    rdf:type rdfs:Class .
-            rdfs:Class                       rdf:type rdfs:Class .
-            rdfs:Literal                     rdf:type rdfs:Class .
-            rdf:XMLLiteral                   rdf:type rdfs:Class .
-            rdf:JSON                         rdf:type rdfs:Class .
-            rdf:HTML                         rdf:type rdfs:Class .
-            rdfs:Datatype                    rdf:type rdfs:Class .
-            rdf:Seq                          rdf:type rdfs:Class .
-            rdf:Bag                          rdf:type rdfs:Class .
-            rdf:Alt                          rdf:type rdfs:Class .
-            rdfs:Container                   rdf:type rdfs:Class .
-            rdf:List                         rdf:type rdfs:Class .
-            rdfs:ContainerMembershipProperty rdf:type rdfs:Class .
-            rdf:Property                     rdf:type rdfs:Class .
-            rdf:Statement                    rdf:type rdfs:Class .
-            
-            rdfs:domain                      rdf:type rdf:Property .
-            rdfs:range                       rdf:type rdf:Property .
-            rdfs:subPropertyOf               rdf:type rdf:Property .
-            rdfs:subClassOf                  rdf:type rdf:Property .
-            rdfs:member                      rdf:type rdf:Property .
-            rdfs:seeAlso                     rdf:type rdf:Property .
-            rdfs:isDefinedBy                 rdf:type rdf:Property .
-            rdfs:comment                     rdf:type rdf:Property .
-            rdfs:label                       rdf:type rdf:Property .
-          </pre>
-        </div>
-      </section>
-      <p>RDFS does not partition the universe into disjoint categories of classes, properties and individuals.
-        Anything in the universe can be used as a class or as a property, or both,
-        while retaining its status as an individual which may be in classes and have properties.
-        Thus, RDFS permits classes which contain other classes, classes of properties, properties of classes, etc.
-        As the axiomatic triples above illustrate, it also permits classes which contain themselves and properties
-        which apply to themselves.
-        A property of a class is not necessarily a property of its members, nor vice versa.
-      </p>
-      <section id="rdfs_literal_note" class="informative">
-        <h4>A note on rdfs:Literal (Informative)</h4>
-        <p>The class <code>rdfs:Literal</code> is not the class of literals,
-          but rather that of literal values, which may also be denoted by IRIs.
-          For example, LV does not contain the literal <code>"foodle"^^xsd:string</code>
-          but it does contain the string "foodle".
-        </p>
-        <p>A triple of the form</p>
-        <p><code>ex:a rdf:type rdfs:Literal .</code></p>
-        <p>is consistent even though its subject is an IRI rather
-          than a literal. It says that the IRI '<code>ex:a</code>'
-          <a>denotes</a> a literal value, which is quite possible since literal values are things in the universe.
-          Blank nodes may range over literal values, for the same reason.
-        </p>
-      </section>
-      <section id="rdfs_entailment">
-        <h3>RDFS entailment</h3>
-        <p>S <dfn>RDFS entails</dfn> <em>E</em> <strong>recognizing D</strong> when every <a>RDFS interpretation</a> recognizing D
-          which <a>satisfies</a> <em>S</em> also satisfies <em>E</em>.
-        </p>
-        <p> Since every <a>RDFS interpretation</a> is an <a>RDF interpretation</a>,
-          if <em>S</em> <a>RDFS entails</a> <em>E</em> then <em>S</em> also <a>RDF entail</a>s E;
-          but RDFS entailment is stronger than RDF entailment.
-          Even the empty graph has a large number of RDFS entailments which are not RDF entailments,
-          for example all triples of the form 
-        </p>
-        <p> aaa <code>rdf:type rdfs:Resource .</code></p>
-        <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
-        <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
-          <h4>Patterns of RDFS entailment (Informative)</h4>
-          <P>RDFS entailment holds for all the following patterns, 
-            which correspond closely to the RDFS semantic conditions:
-          </p>
-          <table id="rdfs_entailment_patterns">
-            <caption>RDFS entailment patterns.</caption>
-            <tbody>
-              <tr >
-                <th ></th>
-                <th >If <em>S</em> contains:</th>
-                <th >then <em>S</em> RDFS <a>entails recognizing D</a>:</th>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs1</dfn></td>
-                <td class="othertable">any IRI aaa in D</td>
-                <td class="othertable">aaa <code>rdf:type rdfs:Datatype . </code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs2</dfn></td>
-                <td class="othertable"> aaa <code>rdfs:domain</code> xxx <code>.</code><br>
-                  yyy aaa zzz <code>.</code>
-                </td>
-                <td class="othertable">yyy <code>rdf:type</code> xxx <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs3</dfn></td>
-                <td class="othertable">aaa <code>rdfs:range</code> xxx <code>.</code><br>
-                  yyy aaa zzz <code>.</code>
-                </td>
-                <td class="othertable">zzz <code>rdf:type</code> xxx <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs4a</dfn></td>
-                <td class="othertable">xxx aaa yyy <code>.</code></td>
-                <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs4b</dfn></td>
-                <td class="othertable">xxx aaa yyy<code>.</code></td>
-                <td class="othertable">yyy <code>rdf:type rdfs:Resource .</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs5</dfn></td>
-                <td class="othertable"> xxx <code>rdfs:subPropertyOf</code> yyy <code>.</code><br>
-                  yyy <code>rdfs:subPropertyOf</code> zzz <code>.</code>
-                </td>
-                <td class="othertable">xxx <code>rdfs:subPropertyOf</code> zzz <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs6</dfn></td>
-                <td class="othertable">xxx <code>rdf:type rdf:Property .</code></td>
-                <td class="othertable">xxx <code>rdfs:subPropertyOf</code> xxx <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs7</dfn></td>
-                <td class="othertable"> aaa <code>rdfs:subPropertyOf</code> bbb <code>.</code><br>
-                  xxx aaa yyy <code>.</code>
-                </td>
-                <td class="othertable">xxx bbb yyy <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs8</dfn></td>
-                <td class="othertable">xxx <code>rdf:type rdfs:Class .</code></td>
-                <td class="othertable">xxx <code>rdfs:subClassOf rdfs:Resource .</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs9</dfn></td>
-                <td class="othertable">xxx <code>rdfs:subClassOf</code> yyy <code>.</code><br>
-                  zzz <code>rdf:type</code> xxx <code>.</code>
-                </td>
-                <td class="othertable">zzz <code>rdf:type</code> yyy <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs10</dfn></td>
-                <td class="othertable">xxx <code>rdf:type rdfs:Class .</code></td>
-                <td class="othertable">xxx <code>rdfs:subClassOf</code> xxx <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs11</dfn></td>
-                <td class="othertable"> xxx <code>rdfs:subClassOf</code> yyy <code>.</code><br>
-                  yyy <code>rdfs:subClassOf</code> zzz <code>.</code>
-                </td>
-                <td class="othertable">xxx <code>rdfs:subClassOf</code> zzz <code>.</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs12</dfn></td>
-                <td class="othertable">xxx <code>rdf:type rdfs:ContainerMembershipProperty .</code></td>
-                <td class="othertable">xxx <code>rdfs:subPropertyOf rdfs:member .</code></td>
-              </tr>
-              <tr >
-                <td class="othertable"><dfn>rdfs13</dfn></td>
-                <td class="othertable">xxx <code>rdf:type rdfs:Datatype .</code></td>
-                <td class="othertable">xxx <code>rdfs:subClassOf rdfs:Literal .</code></td>
-              </tr>
-            </tbody>
-          </table>
-          <p>RDFS provides for several new ways to be <a>unsatisfiable</a> recognizing D.
-            For example, the following graph is RDFS unsatisfiable recognizing {<code>xsd:integer</code>, <code>xsd:boolean</code>}:
-          </p>
-          <pre class="nohighlight">
-            ex:p rdfs:domain xsd:boolean .
-            ex:a rdf:type    xsd:integer .
-            ex:a ex:p        ex:c .
-          </pre>
-        </section>
-      </section>
-    </section>
-    <section id="rdf_datasets">
-      <h2>RDF Datasets</h2>
-      <!--
-        <p>An RDF <a data-cite="RDF12-CONCEPTS#section-dataset">dataset</a> (see [[!RDF12-CONCEPTS]])
-          is a finite set of RDF graphs each paired with an IRI or blank node called the <strong>graph name</strong>,
-          plus a <strong>default graph</strong>, without a name.
-          Graphs in a single dataset may share blank nodes.
-          The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
-          to allow queries to be directed against particular graphs.</p>
-        -->
-      <p><a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF datasets</a>,
-        defined in RDF Concepts [[!RDF12-CONCEPTS]],
-        package up zero or more named RDF graphs along with a single unnamed, default RDF graph.
-        The graphs in a single dataset may share blank nodes.
-        The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
-        to allow queries to be directed against particular graphs.
-      </p>
-      <p>Graph names in a dataset may denote something other than the graph they are paired with.
-        This allows IRIs denoting other kinds of entities, such as persons,
-        to be used in a dataset to <a>identify</a> graphs of information relevant to the entity <a>denoted</a> by the graph name IRI.
-      </p>
-      <p>When a graph name is used inside RDF triples in a dataset it may or may not denote the graph it names.
-        The semantics does not require, nor should RDF engines presume,
-        without some external reason to do so, that graph names used in RDF triples denote to the graph they name.
-      </p>
-      <p>RDF datasets MAY be used to express RDF content.
-        When used in this way, a dataset SHOULD be understood to have at least the same content as its default graph.
-        Note however that replacing the default graph of a dataset by a logically equivalent graph
-        will not in general produce a structurally similar dataset,
-        since it may for example disrupt co-occurrences of blank nodes between the default graph and other graphs in the dataset,
-        which may be important for reasons other than the semantics of the graphs in the dataset.
-      </p>
-      <p>Other <a>semantic extension</a>s and <a>entailment regime</a>s MAY place further semantic conditions and restrictions on RDF datasets,
-        just as with RDF graphs.
-        One such extension, for example, could set up a modal-like interpretation structure so that entailment
-        between datasets would require RDF graph entailments between the graphs with the same name
-        (adding in empty graphs as required).
-      </p>
-    </section>
-    <h2 id="appendices">Appendices</h2>
-    <section id="entailment_rules" class="informative appendix">
-      <h2>Entailment rules (Informative)</h2>
-      <p>(<em>This section is based on work described more fully in </em>[[HORST04]]<em>, </em>[[HORST05]]<em>,
-        which should be consulted for technical details and proofs.</em>) 
-      </p>
-      <p>The RDF and RDFS entailment patterns listed in the above tables can be viewed
-        as left-to-right rules which add the entailed conclusion to a graph.
-        These rule sets can be used to check RDF (or RDFS) entailment between graphs <em>S</em> and <em>E</em>,
-        by the following sequence of operations:
-      </p>
-      <ol>
-        <li>Add to <em>S</em> all the RDF (or RDF and RDFS) axiomatic triples except those containing the container membership property IRIs <code>rdf:_1, rdf:_2, ...</code></li>
-        <li>For every container membership property IRI which occurs in <em>E</em>, add the RDF (or RDF and RDFS) axiomatic triples which contain that IRI.</li>
-        <li>For every IRI <code>aaa</code> used in <em>E</em>, add <code>aaa rdf:type rdfs:Resource</code> to S.</li>
-        <li>Apply the RDF (or RDF and RDFS) inference patterns as rules, adding each conclusion to the graph, to exhaustion; that is, until they generate no new triples.</li>
-        <li>Determine if <em>E</em> has an instance which is a subset of the set, i.e., whether the enlarged set <a>simply entails</a> <em>E</em>.</li>
-      </ol>
-      <p>This process is clearly correct, in that if it gives a positive result then indeed <em>S</em> does RDF (RDFS) entail <em>E</em>.
-        It is not, however, complete: there are cases of <em>S</em> entailing <em>E</em> which are not detectable by this process. Examples include:
-      </p>
+
+  </section>
+</section>
+
+<section id="rdf_d_interpretations">
+  <h2>RDF Interpretations</h2>
+
+  <p>RDF interpretations impose extra semantic conditions on <code>xsd:string</code>
+    and part of the infinite set of IRIs with the namespace prefix <code>rdf:</code> .
+
+  <table>
+    <tbody>
+      <tr>
+        <td ><dfn>RDF vocabulary</dfn></td>
+      </tr>
+
+      <tr>
+        <td ><code>rdf:type rdf:subject rdf:predicate rdf:object
+        <span style="background-color: Cyan;color: Black">rdf:TripleTerm rdf:ReificationProperty rdf:InverseReificationProperty</span>
+          rdf:first rdf:rest rdf:value rdf:nil
+          rdf:List rdf:langString rdf:Property rdf:_1 rdf:_2
+           ...</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>An <dfn>RDF interpretation</dfn> <strong>recognizing D</strong> is a <a>D-interpretation</a> I
+    where D includes <code>rdf:langString</code> and <code>xsd:string</code>, and which satisfies:</p>
+
+  <table>
+    <caption>RDF semantic conditions.</caption>
+    <tbody>
+      <tr>
+        <td class="semantictable" id="rdfsemcond1">x is
+          in IP if and only if &lt;x, I(<code>rdf:Property</code>)&gt; is in IEXT(I(<code>rdf:type</code>))</td>
+      </tr>
+      <tr>
+        <td class="semantictable" id="rdfsemcond3">For every IRI aaa in D, &lt; x,
+          I(aaa) &gt; is in IEXT(I(<code>rdf:type</code>)) if and only if x is in the <a>value space</a> of I(aaa)</td></tr>
+          
+          
+       <tr><td class="semantictable" id="rdfsemcond1"><span style="background-color: Cyan;color: Black">
+if [I+A](E) = TRUE and E.s is a triple term,   then
+          <[I+A](E.s), I(<code>rdf:TripleTerm</code>)> is in IEXT(I(<code>rdf:type</code>))
+      </span></td></tr>
+      
+      <tr><td class="semantictable" id="rdfsemcond1"><span style="background-color: Cyan;color: Black">
+if [I+A](E) = TRUE and E.o is a triple term,  then
+          <[I+A](E.o), I(<code>rdf:TripleTerm</code>)> is in IEXT(I(<code>rdf:type</code>))
+       </span></td></tr>
+       
+      <tr><td class="semantictable" id="rdfsemcond1"><span style="background-color: Cyan;color: Black">
+if [I+A](E) = TRUE and 
+<[I+A](E.o), [I+A](rdf:TripleTerm)> ∈ IEXT(I(<code>rdf:type</code>))
+and E.p ≠ <code>rdf:type</code>, then
+          <[I+A](E.p), I(<code>rdf:ReificationProperty</code>)> is in IEXT(I(<code>rdf:type</code>))
+       </span></td></tr>
+       
+      <tr><td class="semantictable" id="rdfsemcond1"><span style="background-color: Cyan;color: Black">
+if [I+A](E) = TRUE  and
+<[I+A](E.s), [I+A](rdf:TripleTerm)> ∈ IEXT(I(<code>rdf:type</code>))
+and E.p<code>rdf:type</code>, then
+          <[I+A](E.p), I(<code>rdf:InverseReificationProperty</code>)> is in IEXT(I(<code>rdf:type</code>))
+      </span></td></tr>
+
+          
+    </tbody>
+  </table>
+
+  <p>and <a>satisfies</a> every triple in the following infinite set:</p>
+
+  <table>
+   <caption>RDF axioms.</caption>
+    <tr>
+      <td class="ruletable" id="RDF_axiomatic_triples"><code>rdf:type rdf:type rdf:Property .<br/>
+        rdf:subject rdf:type rdf:Property .<br/>
+        rdf:predicate rdf:type rdf:Property .<br/>
+        rdf:object rdf:type rdf:Property .<br/>
+        rdf:first rdf:type rdf:Property .<br/>
+        rdf:rest rdf:type rdf:Property .<br/>
+        rdf:value rdf:type rdf:Property .<br/>
+        rdf:nil rdf:type rdf:List .<br/>
+        rdf:_1 rdf:type rdf:Property .<br/>
+        rdf:_2 rdf:type rdf:Property .<br/>
+        <span style="background-color: Cyan;color: Black">rdf:reifies rdf:type rdf:ReificationProperty .</span><br/>
+        ...<br/></code>
+        </td>
+    </tr>
+  </table>
+
+  <p>RDF imposes no particular normative meanings on the rest of the RDF vocabulary.
+    <a href="#whatnot">Appendix D</a> describes the intended uses of some of this vocabulary.</p>
+
+  <p>The datatype IRIs <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
+    and <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>
+    MUST be <a>recognized</a> by all RDF interpretations.</p>
+
+  <p>Two other datatypes <a data-cite="RDF12-CONCEPTS#section-XMLLiteral"><code>rdf:XMLLiteral</code></a>
+    and <a data-cite="RDF12-CONCEPTS#section-html"><code>rdf:HTML</code></a> are defined in [[!RDF12-CONCEPTS]].
+    RDF-D interpretations MAY fail to <a>recognize</a> these datatypes.</p>
+
+  <section id="rdf_entail">
+    <h3>RDF entailment</h3>
+
+    <p>S <dfn>RDF entail</dfn><strong>s</strong> E <strong>recognizing D</strong>
+      when every <a>RDF interpretation</a> recognizing D which <a>satisfies</a>
+      S also satisfies E. When D is {<code>rdf:langString</code>, <code>xsd:string</code>}
+      then we simply say S <strong>RDF entails</strong> E.
+      E is <dfn>RDF unsatisfiable</dfn><strong> (recognizing D)</strong>
+      when it has no satisfying <a>RDF interpretation</a> (recognizing D).</p>
+
+    <p>The properties of <a>simple entailment</a> described earlier do not all apply to <a>RDF entail</a>ment.
+      For example, all the RDF axioms are true in every <a>RDF interpretation</a>,
+      and so are <a>RDF entail</a>ed by the empty graph, contradicting <a>interpolation</a> for RDF entailment. </p>
+
+    <section id="rdf_entailment_patterns" class="informative">
+      <h4>Patterns of RDF entailment (Informative)</h4>
+
+      <p>The last semantic condition in the above table gives the following entailment pattern for <a>recognized</a> datatype IRIs:</p>
+
       <table>
-        <thead>
-          <tr>
-            <th> </th>
-            <th>RDF entails</th>
-          </tr>
-        </thead>
-        <tbody>
-          <tr>
-            <td class="othertable"><code>ex:a ex:p "string"^^xsd:string .<br>
-              ex:b ex:q "string"^^xsd:string .</code>
-            </td>
-            <td class="othertable"><code>ex:a ex:p _:b .<br>
-              ex:b ex:q _:b .<br>
-              _:b rdf:type xsd:string .</code> 
-            </td>
-          </tr>
-          <tr>
-            <th> </th>
-            <th>RDFS entails</th>
-          </tr>
-          <tr>
-            <td class="othertable"><code>ex:a rdfs:subPropertyOf _:b .<br>
-              _:b rdfs:domain ex:c .<br>
-              ex:d ex:a ex:e .</code>
-            </td>
-            <td class="othertable"><code>ex:d rdf:type ex:c .</code> </td>
-          </tr>
-        </tbody>
-      </table>
-      <p>Both of these can be handled by allowing the rules to apply to a generalization of the RDF syntax
-        in which literals may occur in subject position and blank nodes may occur in predicate position.
-      </p>
-      <!--<p>Define a <dfn>generalized RDF triple</dfn> to be a triple &lt;x, y, z&gt; where x and z can be an IRI, a blank node or a literal, and y can be an IRI or a blank node; and extend this to the rest of RDF, so that a generalized RDF graph is a set of generalized RDF triples. -->
-      <p>Consider <a data-cite="RDF12-CONCEPTS#section-generalized-rdf">generalized RDF triples, graphs, and datasets</a>
-        instead of RDF triples, graphs and datasets (extending the generalization used in [[HORST04]]
-        and following exactly the terms used in [[OWL2-PROFILES]]).
-        The semantics described in this document applies to the generalization without change,
-        so that the notions of interpretation, satisfiability, and entailment can be used freely.
-        Then we can replace the first RDF entailment pattern with the simpler and more direct
-      </p>
-      <table>
-        <caption>G-RDF-D entailment pattern.</caption>
+        <caption>RDF entailment pattern.</caption>
         <tbody>
           <tr>
             <th > </th>
-            <th ><strong>if <em>S</em> contains</strong></th>
-            <th ><strong>then <em>S</em> RDF entails, recognizing D</strong></th>
+            <th ><strong>if S contains</strong></th>
+            <th ><strong>then S RDF entails, recognizing D</strong></th>
           </tr>
           <tr >
-            <td class="othertable"><dfn>GrdfD1</dfn></td>
-            <td class="othertable">   xxx aaa <code>"</code>sss<code>"^^</code>ddd <code>.</code> <br>
-              for ddd in D
-            </td>
-            <td class="othertable"><code>"</code>sss<code>"^^</code>ddd <code>rdf:type</code> ddd <code>.</code></td>
+            <td class="othertable"><dfn>rdfD1</dfn></td>
+            <td class="othertable">   xxx aaa <code>"</code>sss<code>"^^</code>ddd <code>.</code> <br/>
+                for ddd in D</td>
+            <td class="othertable">xxx aaa _:nnn <code>.</code><br/>
+      _:nnn <code>rdf:type</code> ddd <code>.</code></td>
           </tr>
         </tbody>
       </table>
-      <p> which gives the entailments;</p>
-      <pre class="nohighlight">
-        ex:a                 ex:p     "string"^^xsd:string .
-        ex:b                 ex:q     "string"^^xsd:string .
-        "string"^^xsd:string rdf:type xsd:string .</pre>
-      <p>by <a>GrdfD1</a></p>
-      <p>which is an instance (in generalized RDF) of the desired conclusion, above.</p>
-      <p> The second example can be derived using the RDFS rules:</p>
-      <pre class="nohighlight">
-        ex:a rdfs:subPropertyOf _:b .
-        _:b  rdfs:domain        ex:c .
-        ex:d ex:a               ex:e .
-        ex:d _:b                ex:c .
-      </pre>
-      <p>by <a>rdfs7</a></p>
-      <p>
-        <code>ex:d rdf:type ex:c .</code> by <a>rdfs2</a>
-      </p>
-      <p>Where the entailment patterns have been applied to generalized RDF syntax but yield a final conclusion which is legal RDF.</p>
-      <p>With the generalized syntax, these rules are complete for both RDF and RDFS entailment. Stated exactly:</p>
-      <p>Let <em>S</em> and <em>E</em> be RDF graphs. Define the <dfn>generalized RDF (RDFS) closure</dfn> <strong>of <em>S</em> towards E</strong>
-        to be the set obtained by the following procedure.
-      </p>
-      <ol>
-        <li>Add to <em>S</em> all the RDF (and RDFS) axiomatic triples which do not contain any container membership property IRI.</li>
-        <li>For each container membership property IRI which occurs in <em>E</em>, add the RDF (and RDFS) axiomatic triples which contain that IRI.</li>
-        <li>If no triples were added in step 2, add the RDF (and RDFS) axiomatic triples which contain <code>rdf:_1</code>.</li>
-        <li>For every IRI or literal <code>aaa</code> used in <em>E</em>, add <code>aaa rdf:type rdfs:Resource</code> to S.</li>
-        <li>Apply the rules <a>GrdfD1</a>, <a>rdfD1a</a>, and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a>),
-          with D={<code>rdf:langString</code>, <code>xsd:string</code>}, to the set in all possible ways, to exhaustion.
-        </li>
-      </ol>
-      <p>Then we have the completeness result:</p>
-      <p class="fact">If <em>S</em> is RDF (RDFS) consistent, then <em>S</em> RDF entails (RDFS entails) <em>E</em> just
-        when the <a>generalized RDF (RDFS) closure</a> of <em>S</em> towards <em>E</em> <a>simply entails</a> <em>E</em>. 
-      </p>
-      <p>The closures are finite. The generation process is decidable and of polynomial complexity.
-        Detecting simple entailment is NP-complete in general, but of low polynomial order when <em>E</em> contains no blank nodes.
-      </p>
-      <p>Every RDF(S) closure, even starting with the empty graph,
-        will contain all RDF(S) tautologies which can be expressed using the vocabulary of the original graph
-        plus the RDF and RDFS vocabularies.
-        In practice there is little utility in re-deriving these,
-        and a subset of the rules can be used to establish most entailments of practical interest.
-      </p>
-      <p>If it is important to stay within legal RDF syntax, rule <a>rdfD1</a> may be used instead of <a>GrdfD1</a>,
-        and the introduced blank node can be used as a substitute for the literal in subsequent derivations.
-        The resulting set of rules will not however be complete.
-      </p>
-      <p>As noted earlier, detecting datatype entailment for larger sets of datatype IRIs
-        requires attention to idiosyncratic properties of the particular datatypes.
-      </p>
+
+      <p>Note, this is valid even when the literal is <a>ill-typed</a>, since an unsatisfiable graph entails any triple.</p>
+
+      <p>For example,</p>
+
+      <p><code>ex:a ex:p "123"^^xsd:integer .</code></p>
+
+      <p>RDF entails recognizing {<code>xsd:integer</code>}</p>
+
+      <p><code>ex:a ex:p _:x . <br/>
+       _:x rdf:type xsd:integer . </code></p>
+
+      <p>The last semantic condition above also justifies the following entailment pattern:</p>
+
+      <table>
+        <tbody>
+          <tr>
+            <th> </th>
+            <th><strong>any S</strong></th>
+            <th><strong>then S RDF entails, recognizing D</strong></th>
+          </tr>
+          <tr>
+            <td class="othertable"><dfn>rdfD1a</dfn></td>
+            <td class="othertable">for ddd in D with non-empty value space</td>
+            <td class="othertable">_:nnn <code>rdf:type</code> ddd <code>.</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+
+
+      <p>In addition, the first RDF semantic condition justifies the following entailment pattern:</p>
+
+      <table>
+        <tbody>
+          <tr>
+            <th></th>
+            <th><strong>if S contains</strong></th>
+            <th><strong>then S RDF entails, recognizing D</strong></th>
+          </tr>
+
+          <tr>
+             <td class="othertable"><dfn>rdfD2</dfn></td>
+             <td class="othertable">xxx aaa yyy <code>.</code></td>
+             <td class="othertable">aaa <code>rdf:type rdf:Property .</code> </td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>So that the above example also RDF entails</p><p><code>ex:p rdf:type rdf:Property .</code></p>
+      <p> recognizing {<code>xsd:integer</code>}.</p>
+
+      <p>Some datatypes support idiosyncratic entailment patterns which do not hold for other datatypes. For example,</p>
+
+      <p><code> ex:a ex:p "true"^^xsd:boolean .<br/>
+        ex:a ex:p "false"^^xsd:boolean .<br/>
+        ex:v rdf:type xsd:boolean .</code></p>
+
+      <p>together RDF entail</p>
+
+      <p><code>ex:a ex:p ex:v .</code></p>
+
+      <p>recognizing {<code>xsd:boolean</code>}.</p>
+
+      <p>In addition, the semantic conditions on <a>value spaces</a> may produce other <a>unsatisfiable</a> graphs.
+        For example, when D contains <code>xsd:integer</code> and <code>xsd:boolean</code>,
+        then the following is <a>RDF unsatisfiable</a> recognizing D:</p>
+
+      <p><code>_:x rdf:type xsd:boolean .<br/>
+      _:x rdf:type xsd:integer . </code></p>
+      
+      <p><span style="background-color: Cyan;color: Black">
+The semantics conditions for triple terms gives the following RDF entailment pattern: 
+      </span></p>
+      
+         <table style="background-color: Cyan;color: Black">
+        <caption style="background-color: Cyan;color: Black">RDF entailment patterns with triple terms.</caption>
+        <tbody style="background-color: Cyan;color: Black">
+          <tr style="background-color: Cyan;color: Black">
+            <th > </th>
+            <th ><strong>if S contains</strong></th>
+            <th ><strong>then S RDF entails</strong></th>
+          </tr>
+          <tr >
+            <td class="othertable" style="background-color: Cyan;color: Black"><dfn>rdfREIF1</dfn></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">sss aaa ttt <code>.</code><br/> for ttt a triple term</td>
+            <td class="othertable" style="background-color: Cyan;color: Black">aaa <code>rdf:type</code> <code>rdf:ReificationProperty .</code><br/>sss aaa _:nnn <code>.</code><br/>_:nnn <code>rdf:type</code><code> rdf:TripleTerm </code><code>.</code></td>
+          </tr>
+        </tbody>
+      </table>   
+      
+
     </section>
-    <section id="finite_interpretations" class="informative appendix">
-      <h2>Finite interpretations</h2>
-      <p>To keep the exposition simple, the RDF semantics has been phrased in a way which requires interpretations
-        to be larger than absolutely necessary.
-        For example, all interpretations are required to interpret the whole IRI vocabulary,
-        and the universes of all D-interpretations where D contains
-        <code>xsd:string</code> must contain all possible strings and therefore be infinite.
-        This appendix sketches, without proof, how to re-state the semantics using smaller semantic structures
-        without changing any entailments. 
-      </p>
-      <p>Basically, it is only necessary for an interpretation structure to interpret the <a>names</a>
-        actually used in the graphs whose entailment is being considered, and to consider interpretations
-        whose universes are at most as big as the number of names and blank nodes in the graphs.
-        More formally, we can define a <dfn>pre-interpretation</dfn> over a <a>vocabulary</a> <em>V</em> to be a structure <em>I</em>
-        similar to a <a>simple interpretation</a> but with a mapping only from V to its universe IR.
-        Then when determining whether <em>G</em> entails <em>E</em>, consider only pre-interpretations over the finite vocabulary
-        of <a>names</a> actually used in <em>G</em> union <em>E</em>. The universe of such a pre-interpretation can be restricted to the cardinality N+B+1, where N is the size of the vocabulary and B is the number of blank nodes in the graphs. Any such pre-interpretation may be extended to <a>simple interpretation</a>s, all of which will give the same truth values for any triples in <em>G</em> or <em>E</em>. Satisfiability, entailment and so on can then be defined with respect to these finite pre-interpretations, and shown to be identical to the ideas defined in the body of the specification.
-      </p>
-      <p>When considering D-entailment, <a>pre-interpretation</a>s may be kept finite
-        by weakening the semantic conditions for literals so that <em>IR</em> needs to contain literal values
-        only for literals which actually occur in <em>G</em> or <em>E</em>, and the size of the universe restricted to (N+B)×(D+1),
-        where D is the number of recognized datatypes.
-        (A tighter bound is possible.) For RDF entailment,
-        only the finite part of the RDF vocabulary which includes those container membership properties
-        which actually occur in the graphs need to be interpreted,
-        and the second RDF semantic condition is weakened to apply only to values
-        which are values of literals which actually occur in the vocabulary.
-        For RDFS interpretations, again only that finite part of the infinite container membership property vocabulary
-        which actually occurs in the graphs under consideration needs to be interpreted.
-        In all these cases, a <a>pre-interpretation</a> of the vocabulary of a graph may be extended to a full interpretation
-        of the appropriate type without changing the truth-values of any triples in the graphs.
-      </p>
-      <p>The whole semantics could be stated in terms of <a>pre-interpretation</a>s,
-        yielding the same entailments, and allowing finite RDF graphs to be interpreted in finite structures,
-        if the <em>finite model property</em> is considered important.
-      </p>
+  </section>
+</section>
+
+<section id="rdfs_interpretations">
+  <h2>RDFS Interpretations</h2>
+
+  <p>RDF Schema [[RDF12-SCHEMA]]
+    extends RDF to a larger vocabulary
+    with more complex semantic constraints:</p>
+
+  <table>
+    <tbody>
+      <tr>
+        <td ><dfn>RDFS vocabulary</dfn></td>
+      </tr>
+
+      <tr>
+        <td ><code>rdfs:domain rdfs:range rdfs:Resource rdfs:Literal
+        rdfs:Datatype rdfs:Class rdfs:subClassOf rdfs:subPropertyOf
+        rdfs:member rdfs:Container rdfs:ContainerMembershipProperty
+        rdfs:comment rdfs:seeAlso rdfs:isDefinedBy
+        rdfs:label</code></td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>(<code>rdfs:comment</code>,<code> rdfs:seeAlso</code>, <code>rdfs:isDefinedBy</code>
+    and <code>rdfs:label</code> are included here because some constraints which
+    apply to their use can be stated using <code>rdfs:domain</code>,<code> rdfs:range</code>
+    and <code>rdfs:subPropertyOf</code>. Other than this, the formal semantics does
+    not constrain their meanings.)</p>
+
+  <p>It is convenient to state the RDFS semantics
+    in terms of a new semantic construct, a <dfn>class</dfn>, i.e. a resource which represents
+    a set of things in the universe which all have that class as a value of their
+    <code>rdf:type</code> property. <a>Class</a>es are defined to be things of type <code>rdfs:Class</code>,
+    and the set of all classes in an interpretation will be called IC.
+    The semantic conditions are stated in terms of a mapping ICEXT (for the <em>C</em>lass
+    <em>Ext</em>ension in I) from IC to the set of subsets of IR.</p><p> A class may have an
+    empty class extension. Two different classes can have the same class extension.
+    The class extension of <code>rdfs:Class</code> contains the class <code>rdfs:Class</code>.</p>
+
+  <p> An <dfn>RDFS interpretation</dfn> (<strong>recognizing D</strong>) is an <a>RDF interpretation</a> (recognizing D) I
+    which <a>satisfies</a> the semantic conditions in the following table, and all the triples in the subsequent table of RDFS axiomatic triples.</p>
+
+  <table id="rdfs_semantic_conditions">
+    <caption>RDFS semantic conditions.</caption>
+    <tr>
+      <td class="semantictable" id="rdfssemcond1"> <p>ICEXT(y) is defined to be { x : &lt; x,y &gt; is in IEXT(I(<code>rdf:type</code>)) }</p>
+        <p>IC is defined to be ICEXT(I(<code>rdfs:Class</code>))</p>
+        <p>LV is defined to be ICEXT(I(<code>rdfs:Literal</code>))</p>
+        <p>ICEXT(I(<code>rdfs:Resource</code>)) = IR</p>
+        <p>ICEXT(I(<code>rdf:langString</code>)) is the set {I(E) : E a language-tagged string }</p>
+        <p>for every other IRI aaa in D, ICEXT(I(aaa)) is the <a>value space</a> of I(aaa)</p>
+        <p>for every IRI aaa in D, I(aaa) is in ICEXT(I(<code>rdfs:Datatype</code>))</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond2"> <p>If
+        &lt; x,y &gt; is in IEXT(I(<code>rdfs:domain</code>)) and &lt; u,v &gt; is
+        in IEXT(x) then u is in ICEXT(y)</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond3"> <p>If
+        &lt; x,y &gt; is in IEXT(I(<code>rdfs:range</code>)) and &lt; u,v &gt; is
+        in IEXT(x) then v is in ICEXT(y)</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond4"><p>IEXT(I(<code>rdfs:subPropertyOf</code>))
+        is transitive and reflexive on IP</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond5"> <p>If
+        &lt;x,y&gt; is in IEXT(I(<code>rdfs:subPropertyOf</code>)) then x and
+        y are in IP and IEXT(x) is a subset of IEXT(y)</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond6"><p>If
+        x is in IC then &lt; x, I(<code>rdfs:Resource</code>) &gt; is in IEXT(I(<code>rdfs:subClassOf</code>))</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond8"><p>IEXT(I(<code>rdfs:subClassOf</code>))
+        is transitive and reflexive on IC</p></td>
+    </tr>
+
+     <tr>
+       <td class="semantictable" id="rdfssemcond7"> <p>If
+          &lt; x,y &gt; is in IEXT(I(<code>rdfs:subClassOf</code>)) then x and y are
+          in IC and ICEXT(x) is a subset of ICEXT(y)</p></td>
+    </tr>
+
+    <tr>
+      <td class="semantictable" id="rdfssemcond9"><p>If
+        x is in ICEXT(I(<code>rdfs:ContainerMembershipProperty</code>)) then:<br/>
+        &lt; x, I(<code>rdfs:member</code>) &gt; is in IEXT(I(<code>rdfs:subPropertyOf</code>))<br/></td>
+    </tr>
+    <tr>
+
+    <td class="semantictable" id="rdfssemcond10"><p>If
+      x is in ICEXT(I(<code>rdfs:Datatype</code>)) then <span >&lt; x,
+      I(<code>rdfs:Literal</code>) &gt; is in IEXT(I(<code>rdfs:subClassOf</code>))</span></p></td>
+    </tr>
+  </table>
+
+  <table id="RDFS_axiomatic_triples">
+    <caption>RDFS axiomatic triples.</caption>
+    <tr>
+      <td class="ruletable"> <code>rdf:type rdfs:domain rdfs:Resource .<br/>
+        rdfs:domain rdfs:domain rdf:Property .<br/>
+        rdfs:range rdfs:domain rdf:Property .<br/>
+        rdfs:subPropertyOf rdfs:domain rdf:Property .<br/>
+        rdfs:subClassOf rdfs:domain rdfs:Class .<br/>
+        rdf:subject rdfs:domain rdf:Statement .<br/>
+        rdf:predicate rdfs:domain rdf:Statement .<br/>
+        rdf:object rdfs:domain rdf:Statement .<br/>
+        rdfs:member rdfs:domain rdfs:Resource . <br/>
+        rdf:first rdfs:domain rdf:List .<br/>
+        rdf:rest rdfs:domain rdf:List .<br/>
+        rdfs:seeAlso rdfs:domain rdfs:Resource .<br/>
+        rdfs:isDefinedBy rdfs:domain rdfs:Resource .<br/>
+        rdfs:comment rdfs:domain rdfs:Resource .<br/>
+        rdfs:label rdfs:domain rdfs:Resource .<br/>
+        rdf:value rdfs:domain rdfs:Resource .<br/>
+        <br/>
+        rdf:type rdfs:range rdfs:Class .<br/>
+        rdfs:domain rdfs:range rdfs:Class .<br/>
+        rdfs:range rdfs:range rdfs:Class .<br/>
+        rdfs:subPropertyOf rdfs:range rdf:Property .<br/>
+        rdfs:subClassOf rdfs:range rdfs:Class .<br/>
+        rdf:subject rdfs:range rdfs:Resource .<br/>
+        rdf:predicate rdfs:range rdfs:Resource .<br/>
+        rdf:object rdfs:range rdfs:Resource .<br/>
+        rdfs:member rdfs:range rdfs:Resource .<br/>
+        rdf:first rdfs:range rdfs:Resource .<br/>
+        rdf:rest rdfs:range rdf:List .<br/>
+        rdfs:seeAlso rdfs:range rdfs:Resource .<br/>
+        rdfs:isDefinedBy rdfs:range rdfs:Resource .<br/>
+        rdfs:comment rdfs:range rdfs:Literal .<br/>
+        rdfs:label rdfs:range rdfs:Literal .<br/>
+        rdf:value rdfs:range rdfs:Resource .<br/>
+        <br/>
+        rdf:Alt rdfs:subClassOf rdfs:Container .<br/>
+        rdf:Bag rdfs:subClassOf rdfs:Container .<br/>
+        rdf:Seq rdfs:subClassOf rdfs:Container .<br/>
+        rdfs:ContainerMembershipProperty rdfs:subClassOf rdf:Property .<br/>
+        <br/>
+        rdfs:isDefinedBy rdfs:subPropertyOf rdfs:seeAlso .<br/>
+        <br/>
+
+        rdfs:Datatype rdfs:subClassOf rdfs:Class .<br/>
+        <br/>
+        rdf:_1 rdf:type rdfs:ContainerMembershipProperty .<br/>
+        <span >rdf:_1 rdfs:domain rdfs:Resource .<br/>
+        rdf:_1 rdfs:range rdfs:Resource .</span> <br/>
+        rdf:_2 rdf:type rdfs:ContainerMembershipProperty .<br/>
+        rdf:_2 rdfs:domain rdfs:Resource .<br/>
+        rdf:_2 rdfs:range rdfs:Resource . <br/>
+        </code>... <br/> </td>
+    </tr>
+  </table>
+
+  <p class="changenote">In the 2004 RDF 1.0 semantics, LV was defined as part of a simple interpretation structure,
+    and the definition given here was a constraint. </p>
+
+  <p>Since I is an <a>RDF interpretation</a>, the first condition implies that IP
+    = ICEXT(I(<code>rdf:Property</code>)).</p>
+
+  <p>The semantic conditions on <a>RDF interpretation</a>s,
+    together with the RDFS conditions on ICEXT, mean that every <a>recognized</a> datatype
+    can be treated as a class whose extension is the <a>value space</a> of the datatype,
+    and every literal with that datatype either fails to denote, or <a>denotes</a> a value in that class.</p>
+
+  <p>When using RDFS semantics, the referents of all <a>recognized</a> datatype IRIs can be considered
+    to be in the <a>class</a> <code>rdfs:Datatype</code>.</p>
+
+  <p>The axioms and conditions listed above have some redundancy. For example, all but one
+    of the RDF axiomatic triples can be derived from the RDFS axiomatic triples
+    and the semantic conditions on ICEXT,<code> rdfs:domain</code> and <code>rdfs:range</code>. </p>
+
+  <p>Other triples which must be true in all RDFS interpretations
+    include the following. This is not a complete set.</p>
+
+  <table>
+    <caption>Some rdfs-valid triples.</caption>
+    <tr>
+      <td class="ruletable"><code>rdfs:Resource rdf:type rdfs:Class .<br/>
+        rdfs:Class rdf:type rdfs:Class .<br/>
+        rdfs:Literal rdf:type rdfs:Class .<br/>
+        rdf:XMLLiteral rdf:type rdfs:Class .<br/>
+  rdf:HTML rdf:type rdfs:Class .<br/>
+        rdfs:Datatype rdf:type rdfs:Class .<br/>
+        rdf:Seq rdf:type rdfs:Class .<br/>
+        rdf:Bag rdf:type rdfs:Class .<br/>
+        rdf:Alt rdf:type rdfs:Class .<br/>
+        rdfs:Container rdf:type rdfs:Class .<br/>
+        rdf:List rdf:type rdfs:Class .<br/>
+        rdfs:ContainerMembershipProperty rdf:type rdfs:Class .<br/>
+        rdf:Property rdf:type rdfs:Class .<br/>
+        rdf:Statement rdf:type rdfs:Class .<br/>
+        <br/>
+        rdfs:domain rdf:type rdf:Property .<br/>
+        rdfs:range rdf:type rdf:Property .<br/>
+        rdfs:subPropertyOf rdf:type rdf:Property .<br/>
+        rdfs:subClassOf rdf:type rdf:Property .<br/>
+        rdfs:member rdf:type rdf:Property .<br/>
+        rdfs:seeAlso rdf:type rdf:Property .<br/>
+        rdfs:isDefinedBy rdf:type rdf:Property .<br/>
+        rdfs:comment rdf:type rdf:Property .<br/>
+        rdfs:label rdf:type rdf:Property .<br/>
+        </code><code></code></td>
+    </tr>
+  </table>
+
+  <p>RDFS does not partition the universe into disjoint categories of classes, properties and individuals.
+    Anything in the universe can be used as a class or as a property, or both,
+    while retaining its status as an individual which may be in classes and have properties.
+    Thus, RDFS permits classes which contain other classes, classes of properties, properties of classes, etc.
+    As the axiomatic triples above illustrate, it also permits classes which contain themselves and properties
+    which apply to themselves.
+    A property of a class is not necessarily a property of its members, nor vice versa.</p>
+
+  <section id="rdfs_literal_note" class="informative">
+    <h4>A note on rdfs:Literal (Informative)</h4>
+
+    <p>The class <code>rdfs:Literal</code> is not the class of literals,
+      but rather that of literal values, which may also be denoted by IRIs.
+      For example, LV does not contain the literal <code>"foodle"^^xsd:string</code>
+      but it does contain the string "foodle".</p>
+
+    <p>A triple of the form</p>
+
+    <p><code>ex:a rdf:type rdfs:Literal .</code></p>
+
+    <p>is consistent even though its subject is an IRI rather
+      than a literal. It says that the IRI '<code>ex:a</code>'
+      <a>denotes</a> a literal value, which is quite possible since literal values are things in the universe.
+      Blank nodes may range over literal values, for the same reason.</p>
+
+  </section>
+
+  <section id="rdfs_entailment">
+    <h3>RDFS entailment</h3>
+
+    <p>S <dfn>RDFS entails</dfn> E <strong>recognizing D</strong> when every <a>RDFS interpretation</a> recognizing D
+      which <a>satisfies</a> S also satisfies E.</p>
+
+    <p> Since every <a>RDFS interpretation</a> is an <a>RDF interpretation</a>,
+      if S <a>RDFS entails</a> E then S also <a>RDF entail</a>s E;
+      but RDFS entailment is stronger than RDF entailment.
+      Even the empty graph has a large number of RDFS entailments which are not RDF entailments,
+      for example all triples of the form </p>
+
+    <p> aaa <code>rdf:type rdfs:Resource .</code></p>
+
+    <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
+
+    <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
+      <h4>Patterns of RDFS entailment (Informative)</h4>
+
+      <P>RDFS entailment holds for all the following patterns, 
+        which correspond closely to the RDFS semantic conditions:</p>
+
+      <table id="rdfs_entailment_patterns">
+        <caption>RDFS entailment patterns.</caption>
+        <tbody>
+          <tr >
+            <th ></th>
+            <th >If S contains:</th>
+            <th >then S RDFS <a>entails recognizing D</a>:</th>
+          </tr>
+          <tr >
+           <td class="othertable"><dfn>rdfs1</dfn></td>
+           <td class="othertable">any IRI aaa in D</td>
+           <td class="othertable">aaa <code>rdf:type rdfs:Datatype . </code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs2</dfn></td>
+            <td class="othertable"> aaa <code>rdfs:domain</code> xxx <code>.</code><br />
+                yyy aaa zzz <code>.</code></td>
+            <td class="othertable">yyy <code>rdf:type</code> xxx <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs3</dfn></td>
+            <td class="othertable">aaa <code>rdfs:range</code> xxx <code>.</code><br />
+                yyy aaa zzz <code>.</code></td>
+            <td class="othertable">zzz <code>rdf:type</code> xxx <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs4a</dfn></td>
+            <td class="othertable">xxx aaa yyy <code>.</code></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs4b</dfn></td>
+            <td class="othertable">xxx aaa yyy<code>.</code></td>
+            <td class="othertable">yyy <code>rdf:type rdfs:Resource .</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs5</dfn></td>
+            <td class="othertable"> xxx <code>rdfs:subPropertyOf</code> yyy <code>.</code><br />
+                yyy <code>rdfs:subPropertyOf</code> zzz <code>.</code></td>
+            <td class="othertable">xxx <code>rdfs:subPropertyOf</code> zzz <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs6</dfn></td>
+            <td class="othertable">xxx <code>rdf:type rdf:Property .</code></td>
+            <td class="othertable">xxx <code>rdfs:subPropertyOf</code> xxx <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs7</dfn></td>
+            <td class="othertable"> aaa <code>rdfs:subPropertyOf</code> bbb <code>.</code><br />
+                xxx aaa yyy <code>.</code></td>
+            <td class="othertable">xxx bbb yyy <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs8</dfn></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:Class .</code></td>
+            <td class="othertable">xxx <code>rdfs:subClassOf rdfs:Resource .</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs9</dfn></td>
+            <td class="othertable">xxx <code>rdfs:subClassOf</code> yyy <code>.</code><br />
+                zzz <code>rdf:type</code> xxx <code>.</code></td>
+            <td class="othertable">zzz <code>rdf:type</code> yyy <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs10</dfn></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:Class .</code></td>
+            <td class="othertable">xxx <code>rdfs:subClassOf</code> xxx <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs11</dfn></td>
+            <td class="othertable"> xxx <code>rdfs:subClassOf</code> yyy <code>.</code><br />
+                yyy <code>rdfs:subClassOf</code> zzz <code>.</code></td>
+            <td class="othertable">xxx <code>rdfs:subClassOf</code> zzz <code>.</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs12</dfn></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:ContainerMembershipProperty .</code></td>
+            <td class="othertable">xxx <code>rdfs:subPropertyOf rdfs:member .</code></td>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs13</dfn></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:Datatype .</code></td>
+            <td class="othertable">xxx <code>rdfs:subClassOf rdfs:Literal .</code></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <p>RDFS provides for several new ways to be <a>unsatisfiable</a> recognizing D.
+        For example, the following graph is RDFS unsatisfiable recognizing {<code>xsd:integer</code>, <code>xsd:boolean</code>}:</p>
+
+      <p><code>ex:p rdfs:domain xsd:boolean .<br/>
+        ex:a rdf:type xsd:integer .<br/>
+        ex:a ex:p ex:c .</code></p>
+
     </section>
-    <section id="proofs" class="informative appendix">
-      <h2>Proofs of some results (Informative)</h2>
-      <p class="fact">
-        The <a>empty graph</a> is simply entailed by
-        any graph, and does not simply entail any graph except itself.
-        <!-- <a href="#emptygraphlemmaprf" class="termref">[Proof]</a> -->
-      </p>
-      <p>The empty graph is true in all simple interpretations, so is entailed by any graph.
-        If <em>G</em> contains a triple &lt;a b c&gt;, then any simple interpretation <em>I</em> with <em>IEXT(I(b))={ }</em> makes <em>G</em> false;
-        so the empty graph does not entail <em>G</em>. QED.
-      </p>
-      <p class="fact">
-        A graph <a>simply entails</a> all its <a>subgraphs</a>.
-        <!-- <a href="#subglemprf" class="termref">[Proof]</a> -->
-      </p>
-      <p>If <em>I</em> <a>satisfies</a> <em>G</em> then it satisfies every triple in <em>G</em>, hence every triple in any subset of <em>G</em>. QED.</p>
-      <p class="fact">
-        A graph
-        is simply entailed by any of its <a>instance</a>s.
-        <!-- <a href="#instlemprf" class="termref"> [Proof]</a> -->
-      </p>
-      <p>Suppose <em>H</em> is an instance of <em>G</em> with the instantiation mapping <em>M</em>, and that <em>I</em> <a>satisfies</a> <em>H</em>.
-        For blank nodes <em>n</em> in <em>G</em> which are not in <em>H</em> define <em>A(n)=I(M(n))</em>; then <em>I+A</em> satisfies <em>G</em>, so <em>I</em> satisfies <em>G</em>. QED.
-      </p>
-      <p class="fact">Every graph is simply <a>satisfiable</a>.</p>
-      <p>Consider the simple interpretation with universe {x}, <em>IEXT(x)= &lt;x,x &gt;</em> and <em>I(aaa)=x</em> for any IRI <em>aaa</em>. This interpretation satisfies every RDF graph. QED.</p>
-      <p class="fact">
-        <em>G</em> <a>simply entails</a> a graph <em>E</em> if and only if a <a>subgraph</a> of <em>G</em> is an instance of <em>E</em>.
-      </p>
-      <p>If a <a>subgraph</a> <em>E'</em> of <em>G</em> is an instance of <em>E</em> then <em>G</em> entails <em>E'</em> which entails <em>E</em>,
-        so <em>G</em> entails <em>E</em>. Now suppose <em>G</em> entails <em>E</em>, and consider the
-        <a href="http://en.wikipedia.org/wiki/Herbrand_interpretation">Herbrand interpretation</a> <em>I</em> of <em>G</em> defined as follows.
-        IR contains the <a>names</a> and blank nodes which occur in the graph, with <em>I(n)=n</em>
-        for each <a>name</a> <em>n</em>; <em>n</em> is in <em>IP</em> and <em>&lt;a, b&gt;</em> in <em>IEXT(n)</em> just when the triple <em>&lt;a n b&gt;</em> is in the graph.
-        (For IRIs which do not occur in the graph, assign them values in <em>IR</em> at random.)
-        <em>I</em> <a>satisfies</a> every triple <em>&lt;s p o&gt;</em> in <em>E</em>; that is,
-        for some mapping <em>A</em> from the blank nodes of <em>E</em> to the vocabulary of <em>G</em>,
-        the triple <em>&lt;[I+A](s) I(p) [I+A](o)&gt;</em> occurs in <em>G</em>. But this is an instance of <em>&lt;s p o&gt;</em>
-        under the instance mapping A; so an instance of <em>E</em> is a <a>subgraph</a> of <em>G</em>. QED.
-      </p>
-      <p class="fact">if <em>E</em> is lean and <em>E'</em> is a proper instance of <em>E</em>, then <em>E</em> does not simply entail <em>E'</em>.</p>
-      <p>Suppose <em>E</em> entails <em>E'</em>, then a <a>subgraph</a> of <em>E</em> is an instance of <em>E'</em>, which is a proper instance of <em>E</em>;
-        so a <a>subgraph</a> of <em>E</em> is a proper instance of <em>E</em>, so <em>E</em> is not lean. QED.
-      </p>
-      <p class="fact">If <em>E</em> contains an IRI which does not occur in <em>S</em>, then <em>S</em> does not simply entail <em>E</em>.</p>
-      <p>IF <em>S</em> entails <em>E</em> then a <a>subgraph</a> of <em>S</em> is an instance of <em>E</em>,
-        so every IRI in <em>E</em> must occur in that <a>subgraph</a>,
-        so must occur in <em>S</em>. QED.
-      </p>
-      <p class="fact">For any graph H, if <em>sk(G)</em> <a>simply entails</a> <em>H</em> then there is a graph <em>H'</em>
-        such that <em>G</em> entails H' and H=sk(H').
-      </p>
-      <p>The skolemization mapping sk substitutes a unique new IRI for each blank node,
-        so it is 1:1, so has an inverse. Define ks to be the inverse mapping
-        which replaces each skolem IRI by the blank node it replaced.
-        Since <em>sk(G)</em> entails H, a <a>subgraph</a> of <em>sk(G)</em> is an instance of <em>H</em>,
-        say A(H) for some instance mapping A on the blank nodes in H.
-        Then ks(A(H)) is a <a>subgraph</a> of <em>G</em>; and <em>ks(A(H))=A(ks(H))</em> since
-        the domains of A and ks are disjoint.
-        So ks(H) has an instance which is a <a>subgraph</a> of <em>G</em>,
-        so is entailed by <em>G</em>; and <em>H=sk(ks(H))</em>. QED.
-      </p>
-      <p class="fact">For any graph <em>H</em> which does not contain any of the "new" IRIs introduced into <em>sk(G)</em>,
-        <em>sk(G)</em> <a>simply entails</a> <em>H</em> if and only if <em>G</em> <a>simply entails</a> <em>H</em>.
-      </p>
-      <p>Using the terminology in the previous proof: if <em>H</em> does not contain any skolem IRIs, then H=ks(H).
-        So if <em>sk(G)</em> entails <em>H</em> then <em>G</em> entails ks(H)=H; and if <em>G</em> entails <em>H</em> then <em>sk(G)</em> entails <em>G</em> entails H, so <em>sk(G)</em> entails H. QED.
-      </p>
-    </section>
-    <section id="whatnot" class="informative appendix">
-      <h2 id="non_semantics">RDF reification, containers and collections (Informative)</h2>
-      <p>The RDF semantic conditions do not place formal constraints on the meaning
-        of much of the RDF vocabulary which is intended for use in describing containers and bounded collections,
-        or the reification vocabulary intended to enable an RDF graph to describe RDF triples.
-        This appendix briefly reviews the intended meanings of this vocabulary. 
-      </p>
-      <p>The omission of these conditions from the formal semantics is a design decision
-        to accommodate variations in existing RDF usage and to make it easier to implement
-        processes to check formal RDF entailment. For example, implementations may decide
-        to use special procedural techniques to implement the RDF collection vocabulary.
-      </p>
-      <section id="Reif">
-        <h3>Reification</h3>
-        <div class="c1">
-          <section class="notoc">
-            <h6 class="defcap">RDF Reification Vocabulary</h6>
-            <ul class="othertable cols">
-              <li><code>rdf:Statement</code></li>
-              <li><code>rdf:subject</code></li>
-              <li><code>rdf:predicate</code></li>
-              <li><code>rdf:object</code></li>
-            </ul>
-          </section>
-        </div>
-        <p>The intended meaning of this vocabulary is to allow an RDF graph to act as metadata describing other RDF triples. </p>
-        <p>Consider an example graph containing a single triple:</p>
-        <p><code>ex:a ex:b ex:c .</code></p>
-        <p>and suppose that IRI <code>ex:graph1</code> is used to <a>identify</a> this graph.
-          Exactly how this identification is achieved is external to the RDF model,
-          but it might be by the IRI resolving to a concrete syntax document describing the graph,
-          or by the IRI being the associated name of a named graph in a dataset.
-          Assuming that the IRI can be used to denote the triple,
-          then the reification vocabulary allows us to describe the first graph in another graph:
-        </p>
-        <pre class="nohighlight">
-          ex:graph1 rdf:type      rdf:Statement .
-          ex:graph1 rdf:subject   ex:a .
-          ex:graph1 rdf:predicate ex:b .
-          ex:graph1 rdf:object    ex:c .
-        </pre>
-        <p>The second graph is called a <dfn>reification</dfn> of the triple in the first graph.</p>
-        <p>Reification is not a form of quotation. Rather, the reification describes the
-          relationship between a token of a triple and the resources that the triple denotes. 
-          The value of the <code>rdf:subject</code> property is not the
-          subject IRI itself but the thing it <a>denotes</a>, and similarly for <code>rdf:predicate</code> and <code>rdf:object</code>.
-          For example, if the referent of <code>ex:a</code> is Mount Everest,
-          then the subject of the reified triple is also the mountain, not the IRI which denotes it.
-        </p>
-        <p><a>Reification</a>s can be written with a blank node as subject,
-          or with an IRI subject which does not <a>identify</a> any concrete realization of a triple,
-          in both of which cases they simply assert the existence of the described triple. 
-        </p>
-        <p>The subject of a <a>reification</a> is intended to denote a concrete realization of an RDF triple, such as a document in a surface syntax, rather than a triple considered as an abstract object.  This supports use cases where properties such as dates of
-          composition or provenance information are applied to the
-          reified triple, which are meaningful only when thought of as
-          denoting a particular instance or token of a triple. 
-        </p>
-        <p>A <a>reification</a> of a triple does not entail the triple, and is not entailed by it.
-          The <a>reification</a> only says that the triple token exists and what it is about,
-          not that it is true, so it does not entail the triple.
-          On the other hand, asserting a triple does not automatically imply that any
-          triple tokens exist in the universe being described by the triple.
-          For example, the triple might be part of an ontology describing
-          animals, which could be satisfied by an interpretation in which the
-          universe contained only animals, and in which a <a>reification</a> of it was therefore
-          false.
-        </p>
-        <p>Since the relation between triples and <a>reification</a>s of triples
-          in any RDF graph or graphs need not be one-to-one, asserting a
-          property about some entity described by a <a>reification</a> need not
-          entail that the same property holds of another such entity, even if
-          it has the same components. For example,
-        </p>
-        <pre class="nohighlight">
-          _:xxx rdf:type      rdf:Statement .
-          _:xxx rdf:subject   ex:subject .
-          _:xxx rdf:predicate ex:predicate .
-          _:xxx rdf:object    ex:object .
-          _:yyy rdf:type      rdf:Statement .
-          _:yyy rdf:subject   ex:subject .
-          _:yyy rdf:predicate ex:predicate .
-          _:yyy rdf:object    ex:object .
-          _:xxx ex:property   ex:foo .
-        </pre>
-        <p>does not entail</p>
-        <p><code>_:yyy ex:property ex:foo .</code></p>
-      </section>
-      <section id="containers">
-        <h4>RDF containers</h4>
-        <section class="notoc">
-          <h6 class="defcap">RDF(S) Container Vocabulary</h6>
-          <ul class="othertable cols">
-            <li><code>rdf:Seq</code></li>
-            <li><code>rdf:Bag</code></li>
-            <li><code>rdf:Alt</code></li>
-            <li><code>rdf:_1</code></li>
-            <li><code>rdf:_2</code></li>
-            <li><code>...</code></li>
-            <li><code>rdfs:member</code></li>
-            <li><code>rdfs:Container</code></li>
-            <li><code>rdfs:ContainerMembershipProperty</code></li>
-          </ul>
-        </section>
-        <p>RDF provides vocabularies for describing three classes of
-          containers. Containers have a type, and their members can
-          be enumerated by using a fixed set of <em>container membership
-          properties</em>. These properties are indexed by integers to
-          provide a way to distinguish the members from each other, but these
-          indices should not necessarily be thought of as defining an
-          ordering of the container itself; some containers are considered to be unordered.
-        </p>
-        <p>The <a>RDFS vocabulary</a> adds a generic membership
-          property which holds regardless of position, and classes containing
-          all the containers and all the membership properties.
-        </p>
-        <p>One should understand this vocabulary as <em>describing</em>
-          containers, rather than as a tool for constructing them, as
-          would typically be supplied by a programming language. The actual containers are entities in the semantic universe,
-          and RDF graphs which use the vocabulary simply provide very basic
-          information about these entities, enabling an RDF graph to
-          characterize the container type and give partial information about
-          the members of a container. Since the RDF container vocabulary is
-          so limited, many natural assumptions concerning RDF containers
-          cannot be formally sanctioned by the RDF formal semantics. This should not be taken as
-          meaning that these assumptions are false, but only that RDF does
-          not formally entail that they must be true.
-        </p>
-        <p>There are no special semantic conditions on the container
-          vocabulary: the only structure which RDF presumes its containers
-          to have is what can be inferred from the use of this vocabulary and
-          the general RDF semantic conditions. This amounts to knowing the type of a container, and having a partial
-          enumeration
-          of the items in the container. The intended mode of use is that things
-          of type <code>rdf:Bag</code>
-          are considered to be unordered but to allow duplicates; things of
-          type <code>rdf:Seq</code> are considered to be ordered, and things
-          of type <code>rdf:Alt</code> are considered to represent a
-          collection of alternatives, possibly with a preference ordering.
-          If the container is of an ordered type, then the ordering of items in the container is intended to be
-          indicated by the numerical ordering of the container membership
-          properties, which are assumed to be single-valued.
-          However, these informal conditions are not reflected in any formal RDF
-          entailments.
-        </p>
-        <p>The RDF semantics does not support any entailments which could arise from enumerating
-          the elements of an unordered <code>rdf:Bag</code> in a different order. For example,
-        </p>
-        <pre class="nohighlight">
-          _:xxx rdf:type rdf:Bag .
-          _:xxx rdf:_1   ex:a .
-          _:xxx rdf:_2   ex:b .
-        </pre>
-        <p>does not entail</p>
-        <pre class="nohighlight">_:xxx rdf:_1 ex:b .
-          _:xxx rdf:_2 ex:a .
-        </pre>
-        <p>(If this conclusion were <a>valid</a>, then the result of
-          adding it to the original graph would be <a>entail</a>ed by the graph, and this would assert that both elements were in both
-          positions. This is a consequence of the fact that RDF is a purely
-          assertional language.)
-        </p>
-        <p>There is no assumption that a property of a container applies to
-          any of the elements of the container, or vice versa. 
-        </p>
-        <p>There is no formal requirement that
-          the three container classes are disjoint, so that for example
-          it is consistent to assert that something is both an <code>rdf:Bag</code> and an <code>rdf:Seq</code>.
-          There is no assumption that containers are gap-free, so that for example
-        </p>
-        <pre class="nohighlight">
-          _:xxx rdf:type rdf:Seq.
-          _:xxx rdf:_1   ex:a .
-          _:xxx rdf:_3   ex:c .
-        </pre>
-        <p>does not entail</p>
-        <p><code>_:xxx rdf:_2 _:yyy .</code></p>
-        <p>There is no way in RDF to assert
-          that a container contains only a fixed number of members. This is a
-          reflection of the fact that it is always consistent to add a triple
-          to a graph asserting a membership property of any container. And
-          finally, there is no built-in assumption that an RDF container has
-          only finitely many members.
-        </p>
-      </section>
-      <section id="collections">
-        <span id="rdf-collections">
-          <!-- Alternative identifier -->
-        </span>
-        <h4>RDF collections</h4>
-        <section class="notoc">
-          <h6 class="defcap">RDF Collection Vocabulary</h6>
-          <ul class="othertable cols">
-            <li><code>rdf:List</code></li>
-            <li><code>rdf:first</code></li>
-            <li><code>rdf:rest</code></li>
-            <li><code>rdf:nil</code></li>
-          </ul>
-        </section>
-        <p>RDF provides a vocabulary for describing collections, i.e.'list
-          structures', in terms of head-tail links. Collections differ from
-          containers in allowing branching structure and in having an
-          explicit terminator, allowing applications to determine the exact
-          set of items in the collection.
-        </p>
-        <p>As with containers, no special semantic conditions are imposed on this vocabulary
-          other than the type of <code>rdf:nil</code> being <code>rdf:List</code>. It
-          is intended for use typically in a context where a container is described using
-          blank nodes to connect a 'well-formed' sequence of items, each described by
-          two triples of the form
-        </p>
-        <pre class="nohighlight">
-          _:c1 rdf:first aaa .
-          _:c1 rdf:rest  _:c2 .
-        </pre>
-        <p>where the final item is indicated by the use of <code>rdf:nil</code> as the
-          value of the property <code>rdf:rest</code>. In a familiar convention, <code>rdf:nil</code>
-          can be thought of as the empty collection. Any such graph amounts to an assertion
-          that the collection exists, and since the members of the collection can be determined
-          by inspection, this is often sufficient to enable applications to determine
-          what is meant. The semantics does not require any collections
-          to exist other than those mentioned explicitly in a graph (and the empty collection).
-          For example, the existence of a collection containing two items does not automatically
-          guarantee that the similar collection with the items permuted also exists:
-        </p>
-        <pre class="nohighlight">
-          _:c1 rdf:first ex:aaa .
-          _:c1 rdf:rest  _:c2 .
-          _:c2 rdf:first ex:bbb .
-          _:c2 rdf:rest  rdf:nil .
-        </pre>
-        <p>does not entail</p>
-        <pre class="nohighlight">
-          _:c3 rdf:first ex:bbb .
-          _:c3 rdf:rest  _:c4 .
-          _:c4 rdf:first ex:aaa .
-          _:c4 rdf:rest  rdf:nil .
-        </pre>
-        <p>Also, RDF imposes no 'well-formedness' conditions on the use of this
-          vocabulary, so that it is possible to write RDF graphs which assert
-          the existence of highly peculiar objects such as lists with forked
-          or non-list tails, or multiple heads:
-        </p>
-        <pre class="nohighlight">
-          _:666 rdf:first ex:aaa .
-          _:666 rdf:first ex:bbb .
-          _:666 rdf:rest  ex:ccc .
-          _:666 rdf:rest  rdf:nil .
-        </pre>
-        <p>It is also possible to write a set of triples which under-specify a collection
-          by failing to specify its <code>rdf:rest</code> property value.
-        </p>
-        <p><a>Semantic extension</a>s may
-          place extra syntactic well-formedness restrictions on the use of this vocabulary
-          in order to rule out such graphs. They may
-          exclude interpretations of the collection vocabulary which violate the convention
-          that the subject of a 'linked' collection of two-triple items of the form described
-          above, ending with an item ending with <code>rdf:nil</code>, <a>denotes</a> a totally
-          ordered sequence whose members are the referents of the <code>rdf:first</code>
-          values of the items, in the order got by tracing the <code>rdf:rest</code> properties
-          from the subject to <code>rdf:nil</code>. This permits sequences which contain
-          other sequences.
-        </p>
-        <p> The RDFS semantic conditions require that any
-          subject of the <code>rdf:first</code> property, and any subject or object of
-          the <code>rdf:rest</code> property, be of <code>rdf:type rdf:List</code>. 
-        </p>
-      </section>
-    </section>
-    <section id="Acknowledgments" class="informative appendix" >
-      <h2>Acknowledgments</h2>
-      <p>The basic idea of using an explicit extension mapping to allow self-application without
-        violating the axiom of foundation was suggested by Christopher Menzel.
-        The generalized RDF syntax used in <a href="#entailment_rules" class="sectionRef"></a>,
-        and the example showing the need for it, were suggested by Herman ter Horst,
-        who also proved completeness and complexity results for the rule sets.
-        Jeremy Carroll first showed that simple entailment is NP-complete in general.
-        Antoine Zimmerman suggested several simplifications and improvements to the proofs and presentation.
-      </p>
-      <p>The RDF 1.1 editors acknowledge valuable contributions from Thomas Baker, Dan Brickley, Gavin Carothers,
-        Jeremy Carroll, Pierre-Antoine Champin, Richard Cyganiak, Martin J. Dürst, Alex Hall, Steve Harris, Ivan Herman,
-        Eric Prud'hommeaux, Andy Seaborne, David Wood and Antoine Zimmermann. 
-      </p>
-      <p>This specification draws upon the
-        earlier specification [[RDF-MT]], whose editor acknowledged valuable
-        inputs from  Jeremy Carroll, Dan Connolly, Jan Grant, R. V. Guha,
-        Herman ter Horst, Graham Klyne, Ora Lassilla, Brian McBride, Sergey
-        Melnick, Peter Patel-Schneider, Jos deRoo and Patrick Stickler. 
-        Brian McBride was the series editor for this earlier specification.
-      </p>
-    </section>
-    <section id="ChangeLog-12" class="informative appendix" >
-      <h2>Substantive changes since RDF 1.1</h2>
-      <ul>
-        <li> RDF entailment rule <a>rdfD1a</a> was added in RDF 1.2.  This rule should have been included in RDF 1.1 when the two built-in datatypes (<code>xsd:string</code> and <code>rdf:langString</code>) were added to RDF entailment. </li>
-      </ul>
-    </section>
-    <section id="index"></section>
-  </body>
-</html>
+  </section>
+</section>
+
+<section id="rdf_datasets">
+  <h2>RDF Datasets</h2>
+
+  <!--
+  <p>An RDF <a data-cite="RDF12-CONCEPTS#section-dataset">dataset</a> (see [[!RDF12-CONCEPTS]])
+    is a finite set of RDF graphs each paired with an IRI or blank node called the <strong>graph name</strong>,
+    plus a <strong>default graph</strong>, without a name.
+    Graphs in a single dataset may share blank nodes.
+    The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
+    to allow queries to be directed against particular graphs.</p>
+  -->
+
+  <p><a data-cite="RDF12-CONCEPTS#dfn-rdf-dataset">RDF datasets</a>,
+    defined in RDF Concepts [[!RDF12-CONCEPTS]],
+    package up zero or more named RDF graphs along with a single unnamed, default RDF graph.
+    The graphs in a single dataset may share blank nodes.
+    The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
+    to allow queries to be directed against particular graphs.</p>
+
+  <p>Graph names in a dataset may denote something other than the graph they are paired with.
+    This allows IRIs denoting other kinds of entities, such as persons,
+    to be used in a dataset to <a>identify</a> graphs of information relevant to the entity <a>denoted</a> by the graph name IRI.</p>
+
+  <p>When a graph name is used inside RDF triples in a dataset it may or may not denote the graph it names.
+    The semantics does not require, nor should RDF engines presume,
+    without some external reason to do so, that graph names used in RDF triples denote to the graph they name.</p>
+
+  <p>RDF datasets MAY be used to express RDF content.
+    When used in this way, a dataset SHOULD be understood to have at least the same content as its default graph.
+    Note however that replacing the default graph of a dataset by a logically equivalent graph
+    will not in general produce a structurally similar dataset,
+    since it may for example disrupt co-occurrences of blank nodes between the default graph and other graphs in the dataset,
+    which may be important for reasons other than the semantics of the graphs in the dataset.</p>
+
+  <p>Other <a>semantic extension</a>s and <a>entailment regime</a>s MAY place further semantic conditions and restrictions on RDF datasets,
+    just as with RDF graphs.
+    One such extension, for example, could set up a modal-like interpretation structure so that entailment
+    between datasets would require RDF graph entailments between the graphs with the same name
+    (adding in empty graphs as required).</p>
+
+</section>
+
+<h2 id="appendices">Appendices</h2>
+
+<section id="entailment_rules" class="informative appendix">
+  <h2>Entailment rules (Informative)</h2>
+
+  <p>(<em>This section is based on work described more fully in </em>[[HORST04]]<em>, </em>[[HORST05]]<em>,
+    which should be consulted for technical details and proofs.</em>) </p>
+
+  <p>The RDF and RDFS entailment patterns listed in the above tables can be viewed
+    as left-to-right rules which add the entailed conclusion to a graph.
+    These rule sets can be used to check RDF (or RDFS) entailment between graphs S and E,
+    by the following sequence of operations:</p>
+
+  <ol>
+    <li>Add to S all the RDF (or RDF and RDFS) axiomatic triples except those containing the container membership property IRIs <code>rdf:_1, rdf:_2, ...</code></li>
+    <li>For every container membership property IRI which occurs in E, add the RDF (or RDF and RDFS) axiomatic triples which contain that IRI.</li>
+    <li>For every IRI <code>aaa</code> used in E, add <code>aaa rdf:type rdfs:Resource</code> to S.</li>
+    <li>Apply the RDF (or RDF and RDFS) inference patterns as rules, adding each conclusion to the graph, to exhaustion; that is, until they generate no new triples.</li>
+    <li>Determine if E has an instance which is a subset of the set, i.e., whether the enlarged set <a>simply entails</a> E.</li>
+  </ol>
+
+  <p>This process is clearly correct, in that if it gives a positive result then indeed S does RDF (RDFS) entail E.
+    It is not, however, complete: there are cases of S entailing E which are not detectable by this process. Examples include:</p>
+
+  <table>
+    <thead>
+      <tr>
+        <th> </th>
+        <th>RDF entails</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td class="othertable"><code>ex:a ex:p "string"^^xsd:string .<br/>
+          ex:b ex:q "string"^^xsd:string .</code></td>
+        <td class="othertable"><code>ex:a ex:p _:b .<br/>
+          ex:b ex:q _:b .<br/>
+          _:b rdf:type xsd:string .</code> </td>
+      </tr>
+
+      <tr>
+        <th> </th>
+        <th>RDFS entails</th>
+      </tr>
+
+      <tr>
+        <td class="othertable"><code>ex:a rdfs:subPropertyOf _:b .<br/>
+          _:b rdfs:domain ex:c .<br/>
+          ex:d ex:a ex:e .</code></td>
+       <td class="othertable"><code>ex:d rdf:type ex:c .</code> </td>
+      </tr>
+    </tbody>
+  </table>
+
+  <p>Both of these can be handled by allowing the rules to apply to a generalization of the RDF syntax
+    in which literals may occur in subject position and blank nodes may occur in predicate position.</p>
+
+  <!--<p>Define a <dfn>generalized RDF triple</dfn> to be a triple &lt;x, y, z&gt; where x and z can be an IRI, a blank node or a literal, and y can be an IRI or a blank node; and extend this to the rest of RDF, so that a generalized RDF graph is a set of generalized RDF triples. -->
+
+  <p>Consider <a data-cite="RDF12-CONCEPTS#section-generalized-rdf">generalized RDF triples, graphs, and datasets</a>
+    instead of RDF triples, graphs and datasets (extending the generalization used in [[HORST04]]
+    and following exactly the terms used in [[OWL2-PROFILES]]).
+    The semantics described in this document applies to the generalization without change,
+    so that the notions of interpretation, satisfiability and entailment can be used freely.
+    Then we can replace the first RDF entailment pattern with the simpler and more direct</p>
+
+  <table>
+    <caption>G-RDF-D entailment pattern.</caption>
+    <tbody>
+      <tr>
+        <th > </th>
+        <th ><strong>if S contains</strong></th>
+        <th ><strong>then S RDF entails, recognizing D</strong></th>
+      </tr>
+      <tr >
+        <td class="othertable"><dfn>GrdfD1</dfn></td>
+        <td class="othertable">   xxx aaa <code>"</code>sss<code>"^^</code>ddd <code>.</code> <br/>
+            for ddd in D</td>
+        <td class="othertable"><code>"</code>sss<code>"^^</code>ddd <code>rdf:type</code> ddd <code>.</code></td>
+     </tr>
+    </tbody>
+  </table>
+
+  <p> which gives the entailments;</p>
+
+  <p><code>ex:a ex:p "string"^^xsd:string .<br/>
+    ex:b ex:q "string"^^xsd:string .<br/>
+    "string"^^xsd:string rdf:type xsd:string .</code>  by <a>GrdfD1</a></p>
+
+  <p>which is an instance (in generalized RDF) of the desired conclusion, above.</p>
+  <p> The second example can be derived using the RDFS rules:</p>
+  <p><code>ex:a rdfs:subPropertyOf _:b .<br/>
+    _:b rdfs:domain ex:c .<br/>
+    ex:d ex:a ex:e .<br/>
+    ex:d _:b ex:c .</code>  by <a>rdfs7</a><br/>
+    <code>ex:d rdf:type ex:c .</code> by <a>rdfs2</a></p>
+
+  <p>Where the entailment patterns have been applied to generalized RDF syntax but yield a final conclusion which is legal RDF.</p>
+
+  <p>With the generalized syntax, these rules are complete for both RDF and RDFS entailment. Stated exactly:</p>
+
+  <p>Let S and E be RDF graphs. Define the <dfn>generalized RDF (RDFS) closure</dfn> <strong>of S towards E</strong>
+    to be the set obtained by the following procedure.</p>
+
+  <ol>
+    <li>Add to S all the RDF (and RDFS) axiomatic triples which do not contain any container membership property IRI.</li>
+    <li>For each container membership property IRI which occurs in E, add the RDF (and RDFS) axiomatic triples which contain that IRI.</li>
+    <li>If no triples were added in step 2, add the RDF (and RDFS) axiomatic triples which contain <code>rdf:_1</code>.</li>
+    <li>For every IRI or literal <code>aaa</code> used in E, add <code>aaa rdf:type rdfs:Resource</code> to S.</li>
+    <li>Apply the rules <a>GrdfD1</a>, <a>rdfD1a</a>, and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a>),
+      with D={<code>rdf:langString</code>, <code>xsd:string</code>}, to the set in all possible ways, to exhaustion.</li>
+  </ol>
+
+  <p>Then we have the completeness result:</p>
+
+  <p class="fact">If S is RDF (RDFS) consistent, then S RDF entails (RDFS entails) E just
+    when the <a>generalized RDF (RDFS) closure</a> of S towards E <a>simply entails</a> E. </p>
+
+  <p>The closures are finite. The generation process is decidable and of polynomial complexity.
+    Detecting simple entailment is NP-complete in general, but of low polynomial order when E contains no blank nodes.</p>
+
+  <p>Every RDF(S) closure, even starting with the empty graph,
+    will contain all RDF(S) tautologies which can be expressed using the vocabulary of the original graph
+    plus the RDF and RDFS vocabularies.
+    In practice there is little utility in re-deriving these,
+    and a subset of the rules can be used to establish most entailments of practical interest.</p>
+
+  <p>If it is important to stay within legal RDF syntax, rule <a>rdfD1</a> may be used instead of <a>GrdfD1</a>,
+    and the introduced blank node can be used as a substitute for the literal in subsequent derivations.
+    The resulting set of rules will not however be complete.</p>
+
+  <p>As noted earlier, detecting datatype entailment for larger sets of datatype IRIs
+    requires attention to idiosyncratic properties of the particular datatypes.</p>
+
+         <table style="background-color: Cyan;color: Black">
+        <caption style="background-color: Cyan;color: Black">G-RDF entailment patterns with triple terms.</caption>
+        <tbody style="background-color: Cyan;color: Black">
+          <tr style="background-color: Cyan;color: Black">
+            <th > </th>
+            <th ><strong>if S contains</strong></th>
+            <th ><strong>then S RDF entails</strong></th>
+          </tr>
+          <tr >
+            <td class="othertable" style="background-color: Cyan;color: Black"><dfn>G-rdfREIF1</dfn></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">sss aaa ttt <code>.</code><br/> ttt <code>rdf:type</code> <code>rdf:TripleTerm .</code><br/>for aaa ≠ <code>rdf:type</code></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">aaa <code>rdf:type</code> <code>rdf:ReificationProperty .</code></td>
+          </tr>
+          <tr>
+            <td class="othertable" style="background-color: Cyan;color: Black"><dfn>G-rdfREIF2</dfn></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">ttt aaa ooo <code>.</code><br/> ttt <code>rdf:type</code> <code>rdf:TripleTerm .</code><br/>for aaa ≠ <code>rdf:type</code></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">aaa <code>rdf:type</code> <code>rdf:InverseReificationProperty .</code></td>
+          </tr>
+          <tr>
+          <tr>
+            <td class="othertable" style="background-color: Cyan;color: Black"><dfn>G-rdfTT1</dfn></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">sss aaa ttt <code>.</code><br/> for ttt a triple term</td>
+            <td class="othertable" style="background-color: Cyan;color: Black">ttt <code>rdf:type</code> <code>rdf:TripleTerm .</code></td>
+          </tr>
+            <td class="othertable" style="background-color: Cyan;color: Black"><dfn>G-rdfTT2</dfn></td>
+            <td class="othertable" style="background-color: Cyan;color: Black">ttt aaa ooo <code>.</code><br/> for ttt a triple term</td>
+            <td class="othertable" style="background-color: Cyan;color: Black">ttt <code>rdf:type</code> <code>rdf:TripleTerm .</code></td>
+          </tr>
+        </tbody>
+      </table>   
+
+
+</section>
+
+<section id="finite_interpretations" class="informative appendix">
+  <h2>Finite interpretations</h2>
+
+  <p>To keep the exposition simple, the RDF semantics has been phrased in a way which requires interpretations
+    to be larger than absolutely necessary.
+    For example, all interpretations are required to interpret the whole IRI vocabulary,
+    and the universes of all D-interpretations where D contains
+    <code>xsd:string</code> must contain all possible strings and therefore be infinite.
+    This appendix sketches, without proof, how to re-state the semantics using smaller semantic structures
+     without changing any entailments. </p>
+
+  <p>Basically, it is only necessary for an interpretation structure to interpret the <a>names</a>
+    actually used in the graphs whose entailment is being considered, and to consider interpretations
+    whose universes are at most as big as the number of names and blank nodes in the graphs.
+    More formally, we can define a <dfn>pre-interpretation</dfn> over a <a>vocabulary</a> V to be a structure I
+    similar to a <a>simple interpretation</a> but with a mapping only from V to its universe IR.
+    Then when determining whether G entails E, consider only pre-interpretations over the finite vocabulary
+    of <a>names</a> actually used in G union E. The universe of such a pre-interpretation can be restricted to the cardinality N+B+1, where N is the size of the vocabulary and B is the number of blank nodes in the graphs. Any such pre-interpretation may be extended to <a>simple interpretation</a>s, all of which will give the same truth values for any triples in G or E. Satisfiability, entailment and so on can then be defined with respect to these finite pre-interpretations, and shown to be identical to the ideas defined in the body of the specification.</p>
+
+  <p>When considering D-entailment, <a>pre-interpretation</a>s may be kept finite
+    by weakening the semantic conditions for literals so that IR needs to contain literal values
+    only for literals which actually occur in G or E, and the size of the universe restricted to (N+B)×(D+1),
+    where D is the number of recognized datatypes.
+    (A tighter bound is possible.) For RDF entailment,
+    only the finite part of the RDF vocabulary which includes those container membership properties
+    which actually occur in the graphs need to be interpreted,
+    and the second RDF semantic condition is weakened to apply only to values
+    which are values of literals which actually occur in the vocabulary.
+    For RDFS interpretations, again only that finite part of the infinite container membership property vocabulary
+    which actually occurs in the graphs under consideration needs to be interpreted.
+    In all these cases, a <a>pre-interpretation</a> of the vocabulary of a graph may be extended to a full interpretation
+    of the appropriate type without changing the truth-values of any triples in the graphs.</p>
+
+  <p>The whole semantics could be stated in terms of <a>pre-interpretation</a>s,
+    yielding the same entailments, and allowing finite RDF graphs to be interpreted in finite structures,
+    if the <em>finite model property</em> is considered important.</p>
+
+</section>
+
+<section id="proofs" class="informative appendix">
+  <h2>Proofs of some results (Informative)</h2>
+
+  <p class="fact"> The <a>empty graph</a> is simply entailed by
+    any graph, and does not simply entail any graph except itself.
+  <!-- <a href="#emptygraphlemmaprf" class="termref">[Proof]</a> -->
+  </p>
+
+  <p>The empty graph is true in all simple interpretations, so is entailed by any graph.
+    If G contains a triple &lt;a b c&gt;, then any simple interpretation I with IEXT(I(b))={ } makes G false;
+    so the empty graph does not entail G. QED.</p>
+
+  <p class="fact"> A graph <a>simply entails</a> all its <a>subgraphs</a>.
+  <!-- <a href="#subglemprf" class="termref">[Proof]</a> -->
+  </p>
+
+  <p>If I <a>satisfies</a> G then it satisfies every triple in G, hence every triple in any subset of G. QED.</p>
+
+  <p class="fact"> A graph
+    is simply entailed by any of its <a>instance</a>s.
+  <!-- <a href="#instlemprf" class="termref"> [Proof]</a> -->
+  </p>
+
+  <p>Suppose H is an instance of G with the instantiation mapping M, and that I <a>satisfies</a> H.
+    For blank nodes n in G which are not in H define A(n)=I(M(n)); then I+A satisfies G, so I satisfies G. QED.</p>
+
+  <p class="fact">Every graph is simply <a>satisfiable</a>.</p>
+
+  <p>Consider the simple interpretation with universe {x}, IEXT(x)= &lt;x,x &gt; and I(aaa)=x for any IRI aaa. This interpretation satisfies every RDF graph. QED.</p>
+
+  <p class="fact">
+    G <a>simply entails</a> a graph E if and only if a <a>subgraph</a> of G is an instance of E.
+  </p>
+
+  <p>If a <a>subgraph</a> E' of G is an instance of E then G entails E' which entails E,
+    so G entails E. Now suppose G entails E, and consider the
+    <a href="http://en.wikipedia.org/wiki/Herbrand_interpretation">Herbrand interpretation</a> I of G defined as follows.
+    IR contains the <a>names</a> and blank nodes which occur in the graph, with I(n)=n
+    for each <a>name</a> n; n is in IP and &lt;a, b&gt; in IEXT(n) just when the triple &lt;a n b&gt; is in the graph.
+    (For IRIs which do not occur in the graph, assign them values in IR at random.)
+    I <a>satisfies</a> every triple &lt;s p o&gt; in E; that is,
+    for some mapping A from the blank nodes of E to the vocabulary of G,
+    the triple &lt;[I+A](s) I(p) [I+A](o)&gt; occurs in G. But this is an instance of &lt;s p o&gt;
+    under the instance mapping A; so an instance of E is a <a>subgraph</a> of G. QED.</p>
+
+  <p class="fact">if E is lean and E' is a proper instance of E, then E does not simply entail E'.</p>
+
+  <p>Suppose E entails E', then a <a>subgraph</a> of E is an instance of E', which is a proper instance of E;
+    so a <a>subgraph</a> of E is a proper instance of E, so E is not lean. QED.</p>
+
+  <p class="fact">If E contains an IRI which does not occur in S, then S does not simply entail E.</p>
+
+  <p>IF S entails E then a <a>subgraph</a> of S is an instance of E,
+    so every IRI in E must occur in that <a>subgraph</a>,
+    so must occur in S. QED.</p>
+
+  <p class="fact">For any graph H, if sk(G) <a>simply entails</a> H then there is a graph H'
+    such that G entails H' and H=sk(H').</p>
+
+  <p>The skolemization mapping sk substitutes a unique new IRI for each blank node,
+    so it is 1:1, so has an inverse. Define ks to be the inverse mapping
+    which replaces each skolem IRI by the blank node it replaced.
+    Since sk(G) entails H, a <a>subgraph</a> of sk(G) is an instance of H,
+    say A(H) for some instance mapping A on the blank nodes in H.
+    Then ks(A(H)) is a <a>subgraph</a> of G; and ks(A(H))=A(ks(H)) since
+    the domains of A and ks are disjoint.
+    So ks(H) has an instance which is a <a>subgraph</a> of G,
+    so is entailed by G; and H=sk(ks(H)). QED.</p>
+
+  <p class="fact">For any graph H which does not contain any of the "new" IRIs introduced into sk(G),
+    sk(G) <a>simply entails</a> H if and only if G <a>simply entails</a> H.</p>
+
+  <p>Using the terminology in the previous proof: if H does not contain any skolem IRIs, then H=ks(H).
+    So if sk(G) entails H then G entails ks(H)=H; and if G entails H then sk(G) entails G entails H, so sk(G) entails H. QED.</p>
+
+</section>
+
+<section id="whatnot" class="informative appendix">
+  <h2 id="non_semantics">RDF reification, containers and collections (Informative)</h2>
+
+  <p>The RDF semantic conditions do not place formal constraints on the meaning
+    of much of the RDF vocabulary which is intended for use in describing containers and bounded collections,
+    or the reification vocabulary intended to enable an RDF graph to describe RDF triples.
+    This appendix briefly reviews the intended meanings of this vocabulary. </p>
+
+  <p>The omission of these conditions from the formal semantics is a design decision
+    to accommodate variations in existing RDF usage and to make it easier to implement
+    processes to check formal RDF entailment. For example, implementations may decide
+    to use special procedural techniques to implement the RDF collection vocabulary.</p>
+
+  <section id="Reif">
+    <h3>Reification</h3>
+
+    <div class="c1">
+      <table>
+        <tbody>
+          <tr>
+            <td class="othertable"><strong>RDF reification vocabulary</strong></td>
+          </tr>
+          <tr>
+            <td class="othertable"><code>rdf:Statement rdf:subject rdf:predicate
+                rdf:object</code></td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+
+    <p>The intended meaning of this vocabulary is to allow an RDF graph to act as metadata describing other RDF triples. </p>
+
+    <p>Consider an example graph containing a single triple:</p>
+
+    <p><code>ex:a ex:b ex:c .</code></p>
+
+    <p>and suppose that IRI <code>ex:graph1</code> is used to <a>identify</a> this graph.
+      Exactly how this identification is achieved is external to the RDF model,
+      but it might be by the IRI resolving to a concrete syntax document describing the graph,
+      or by the IRI being the associated name of a named graph in a dataset.
+      Assuming that the IRI can be used to denote the triple,
+      then the reification vocabulary allows us to describe the first graph in another graph:</p>
+
+    <p><code>ex:graph1 rdf:type rdf:Statement .<br/>
+      ex:graph1 rdf:subject ex:a .<br/>
+      ex:graph1 rdf:predicate ex:b .<br/>
+      ex:graph1 rdf:object ex:c .</code></p>
+
+    <p>The second graph is called a <dfn>reification</dfn> of the triple in the first graph.</p>
+
+    <p>Reification is not a form of quotation. Rather, the reification describes the
+      relationship between a token of a triple and the resources that the triple denotes. 
+      The value of the <code>rdf:subject</code> property is not the
+      subject IRI itself but the thing it <a>denotes</a>, and similarly for <code>rdf:predicate</code> and <code>rdf:object</code>.
+      For example, if the referent of <code>ex:a</code> is Mount Everest,
+      then the subject of the reified triple is also the mountain, not the IRI which denotes it.</p>
+
+    <p><a>Reification</a>s can be written with a blank node as subject,
+      or with an IRI subject which does not <a>identify</a> any concrete realization of a triple,
+      in both of which cases they simply assert the existence of the described triple. </p>
+
+    <p>The subject of a <a>reification</a> is intended to denote a concrete realization of an RDF triple, such as a document in a surface syntax, rather than a triple considered as an abstract object.  This supports use cases where properties such as dates of
+      composition or provenance information are applied to the
+      reified triple, which are meaningful only when thought of as
+      denoting a particular instance or token of a triple. </p>
+
+    <p>A <a>reification</a> of a triple does not entail the triple, and is not entailed by it.
+      The <a>reification</a> only says that the triple token exists and what it is about,
+      not that it is true, so it does not entail the triple.
+      On the other hand, asserting a triple does not automatically imply that any
+      triple tokens exist in the universe being described by the triple.
+      For example, the triple might be part of an ontology describing
+      animals, which could be satisfied by an interpretation in which the
+      universe contained only animals, and in which a <a>reification</a> of it was therefore
+      false.</p>
+
+    <p>Since the relation between triples and <a>reification</a>s of triples
+      in any RDF graph or graphs need not be one-to-one, asserting a
+      property about some entity described by a <a>reification</a> need not
+      entail that the same property holds of another such entity, even if
+      it has the same components. For example,</p>
+
+    <p><code>_:xxx rdf:type rdf:Statement .<br/>
+      _:xxx rdf:subject ex:subject .<br/>
+      _:xxx rdf:predicate ex:predicate .<br/>
+      _:xxx rdf:object ex:object .<br/>
+      _:yyy rdf:type rdf:Statement .<br/>
+      _:yyy rdf:subject ex:subject .<br/>
+      _:yyy rdf:predicate ex:predicate .<br/>
+      _:yyy rdf:object ex:object .<br/>
+      _:xxx ex:property ex:foo .</code></p>
+
+    <p>does not entail</p>
+
+    <p><code>_:yyy ex:property ex:foo .</code></p>
+
+  </section>
+
+  <section id="containers">
+    <h4>RDF containers</h4>
+
+    <table>
+      <tbody>
+        <tr>
+          <td class="othertable"><strong>RDF(S) Container Vocabulary</strong></td>
+        </tr>
+        <tr>
+          <td class="othertable"><code>rdf:Seq rdf:Bag rdf:Alt rdf:_1 rdf:_2
+              ... rdfs:member rdfs:Container rdfs:ContainerMembershipProperty</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>RDF provides vocabularies for describing three classes of
+      containers. Containers have a type, and their members can
+      be enumerated by using a fixed set of <em>container membership
+      properties</em>. These properties are indexed by integers to
+      provide a way to distinguish the members from each other, but these
+      indices should not necessarily be thought of as defining an
+      ordering of the container itself; some containers are considered to be unordered.</p>
+
+    <p>The <a>RDFS vocabulary</a> adds a generic membership
+      property which holds regardless of position, and classes containing
+      all the containers and all the membership properties.</p>
+
+    <p>One should understand this vocabulary as <em>describing</em>
+      containers, rather than as a tool for constructing them, as
+      would typically be supplied by a programming language. The actual containers are entities in the semantic universe,
+      and RDF graphs which use the vocabulary simply provide very basic
+      information about these entities, enabling an RDF graph to
+      characterize the container type and give partial information about
+      the members of a container. Since the RDF container vocabulary is
+      so limited, many natural assumptions concerning RDF containers
+      cannot be formally sanctioned by the RDF formal semantics. This should not be taken as
+      meaning that these assumptions are false, but only that RDF does
+      not formally entail that they must be true.</p>
+
+    <p>There are no special semantic conditions on the container
+      vocabulary: the only structure which RDF presumes its containers
+      to have is what can be inferred from the use of this vocabulary and
+      the general RDF semantic conditions. This amounts to knowing the type of a container, and having a partial
+      enumeration
+      of the items in the container. The intended mode of use is that things
+      of type <code>rdf:Bag</code>
+      are considered to be unordered but to allow duplicates; things of
+      type <code>rdf:Seq</code> are considered to be ordered, and things
+      of type <code>rdf:Alt</code> are considered to represent a
+      collection of alternatives, possibly with a preference ordering.
+      If the container is of an ordered type, then the ordering of items in the container is intended to be
+      indicated by the numerical ordering of the container membership
+      properties, which are assumed to be single-valued.
+      However, these informal conditions are not reflected in any formal RDF
+      entailments.</p>
+
+
+    <p>The RDF semantics does not support any entailments which could arise from enumerating
+      the elements of an unordered <code>rdf:Bag</code> in a different order. For example,</p>
+
+    <p><code>_:xxx rdf:type rdf:Bag .<br/>
+       _:xxx rdf:_1 ex:a .<br/>
+       _:xxx rdf:_2 ex:b .</code></p>
+
+    <p>does not entail</p>
+
+    <p><code>_:xxx rdf:_1 ex:b .<br/>
+       _:xxx rdf:_2 ex:a .</code></p>
+
+    <p>(If this conclusion were <a>valid</a>, then the result of
+      adding it to the original graph would be <a>entail</a>ed by the graph, and this would assert that both elements were in both
+      positions. This is a consequence of the fact that RDF is a purely
+      assertional language.)</p>
+
+    <p>There is no assumption that a property of a container applies to
+      any of the elements of the container, or vice versa. </p>
+
+    <p>There is no formal requirement that
+      the three container classes are disjoint, so that for example
+      it is consistent to assert that something is both an <code>rdf:Bag</code> and an <code>rdf:Seq</code>.
+      There is no assumption that containers are gap-free, so that for example</p>
+
+    <p><code>_:xxx rdf:type rdf:Seq.<br/>
+       _:xxx rdf:_1 ex:a .<br/>
+       _:xxx rdf:_3 ex:c .</code></p>
+
+    <p>does not entail</p>
+
+    <p><code>_:xxx rdf:_2 _:yyy .</code></p>
+
+    <p>There is no way in RDF to assert
+      that a container contains only a fixed number of members. This is a
+      reflection of the fact that it is always consistent to add a triple
+      to a graph asserting a membership property of any container. And
+      finally, there is no built-in assumption that an RDF container has
+      only finitely many members.</p>
+  </section>
+
+  <section id="collections">
+    <span id="rdf-collections"><!-- Alternative identifier --></span>
+    <h4>RDF collections</h4>
+
+    <table>
+      <tbody>
+        <tr>
+          <td class="othertable"><strong>RDF Collection Vocabulary</strong></td>
+        </tr>
+        <tr>
+          <td class="othertable"><code>rdf:List rdf:first rdf:rest rdf:nil</code></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <p>RDF provides a vocabulary for describing collections, i.e.'list
+      structures', in terms of head-tail links. Collections differ from
+      containers in allowing branching structure and in having an
+      explicit terminator, allowing applications to determine the exact
+      set of items in the collection.</p>
+
+
+    <p>As with containers, no special semantic conditions are imposed on this vocabulary
+      other than the type of <code>rdf:nil</code> being <code>rdf:List</code>. It
+      is intended for use typically in a context where a container is described using
+      blank nodes to connect a 'well-formed' sequence of items, each described by
+      two triples of the form
+      <code><br/>
+      <br/>
+      _:c1 rdf:first aaa .<br/>
+      _:c1 rdf:rest _:c2 .</code></p>
+
+    <p>where the final item is indicated by the use of <code>rdf:nil</code> as the
+      value of the property <code>rdf:rest</code>. In a familiar convention, <code>rdf:nil</code>
+      can be thought of as the empty collection. Any such graph amounts to an assertion
+      that the collection exists, and since the members of the collection can be determined
+      by inspection, this is often sufficient to enable applications to determine
+      what is meant. The semantics does not require any collections
+      to exist other than those mentioned explicitly in a graph (and the empty collection).
+      For example, the existence of a collection containing two items does not automatically
+      guarantee that the similar collection with the items permuted also exists:
+      <code>
+      <br/><br/>
+      _:c1 rdf:first ex:aaa .<br/>
+      _:c1 rdf:rest _:c2 .<br/>
+      _:c2 rdf:first ex:bbb .<br/>
+      _:c2 rdf:rest rdf:nil . </code></p>
+
+    <p>does not entail</p>
+
+    <p><code>_:c3 rdf:first ex:bbb .<br/>
+      _:c3 rdf:rest _:c4 .<br/>
+      <span >_:c4 rdf:first</span> ex:aaa .<br/>
+     _:c4 rdf:rest rdf:nil .
+     </code></p>
+
+    <p>Also, RDF imposes no 'well-formedness' conditions on the use of this
+      vocabulary, so that it is possible to write RDF graphs which assert
+      the existence of highly peculiar objects such as lists with forked
+      or non-list tails, or multiple heads:</p>
+
+    <p><code>_:666 rdf:first ex:aaa .<br/>
+      _:666 rdf:first ex:bbb .<br/>
+      _:666 rdf:rest ex:ccc .<br/>
+      _:666 rdf:rest rdf:nil . </code></p>
+
+    <p>It is also possible to write a set of triples which under-specify a collection
+      by failing to specify its <code>rdf:rest</code> property value.</p>
+
+    <p><a>Semantic extension</a>s may
+      place extra syntactic well-formedness restrictions on the use of this vocabulary
+      in order to rule out such graphs. They may
+      exclude interpretations of the collection vocabulary which violate the convention
+      that the subject of a 'linked' collection of two-triple items of the form described
+      above, ending with an item ending with <code>rdf:nil</code>, <a>denotes</a> a totally
+      ordered sequence whose members are the referents of the <code>rdf:first</code>
+      values of the items, in the order got by tracing the <code>rdf:rest</code> properties
+      from the subject to <code>rdf:nil</code>. This permits sequences which contain
+      other sequences.</p>
+
+    <p> The RDFS semantic conditions require that any
+      subject of the <code>rdf:first</code> property, and any subject or object of
+      the <code>rdf:rest</code> property, be of <code>rdf:type rdf:List</code>. </p>
+  </section>
+
+</section>
+
+<section id="Acknowledgments" class="informative appendix" >
+  <h2>Acknowledgments</h2>
+
+  <p>The basic idea of using an explicit extension mapping to allow self-application without
+    violating the axiom of foundation was suggested by Christopher Menzel.
+    The generalized RDF syntax used in <a href="#entailment_rules" class="sectionRef"></a>,
+    and the example showing the need for it, were suggested by Herman ter Horst,
+    who also proved completeness and complexity results for the rule sets.
+    Jeremy Carroll first showed that simple entailment is NP-complete in general.
+    Antoine Zimmerman suggested several simplifications and improvements to the proofs and presentation.</p>
+
+  <p>The RDF 1.1 editors acknowledge valuable contributions from Thomas Baker, Dan Brickley, Gavin Carothers,
+    Jeremy Carroll, Pierre-Antoine Champin, Richard Cyganiak, Martin J. Dürst, Alex Hall, Steve Harris, Ivan Herman,
+    Eric Prud'hommeaux, Andy Seaborne, David Wood and Antoine Zimmermann. </p>
+
+  <p>This specification draws upon the
+    earlier specification [[RDF-MT]], whose editor acknowledged valuable
+    inputs from  Jeremy Carroll, Dan Connolly, Jan Grant, R. V. Guha,
+    Herman ter Horst, Graham Klyne, Ora Lassilla, Brian McBride, Sergey
+    Melnick, Peter Patel-Schneider, Jos deRoo and Patrick Stickler. 
+    Brian McBride was the series editor for this earlier specification.</p>
+
+</section>
+
+<section id="ChangeLog-12" class="informative appendix" >
+  <h2>Substantive changes since RDF 1.1</h2>
+
+  <ul>
+    <li> RDF entailment rule <a>rdfD1a</a> was added in RDF 1.2.  This rule should have been included in RDF 1.1 when the two built-in datatypes (<code>xsd:string</code> and <code>rdf:langString</code>) were added to RDF entailment. </li>
+  </ul>
+</section>
+
+<section id="index"></section>
+
+</body></html>


### PR DESCRIPTION
Please check the _minimal_ extension I made to the `rdf-semantics` doc, with the new definitions as in the [RDF-star "working alternative baseline"](https://github.com/w3c/rdf-star-wg/wiki/RDF-star-%22working-alternative-baseline%22) spec we voted.
Note that I had to make a minor fix to the [RDF alternative semantics](https://github.com/w3c/rdf-star-wg/wiki/RDF-star-%22working-alternative-baseline%22) spec, in order to exclude that `rdf:type` becomes a `rdf:ReificationProperty`.
The `rdf-semantics` doc has been monotonically extended with the necessary new definitions about triple terms.
This version implements a minimal change, since it could be possible also to enhance the quality of the current text.