### PR TITLE
Add simple semantics to RDF-semantics

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -469,7 +469,7 @@
       </tr>
 
       <tr>
-        <td class="semantictable">if E is a ground triple `s p o.`
+        <td class="semantictable">if E is a ground triple `s p o.`,
           then I(E) = true if<br/>
           I(p) is in IP and the pair &lt;I(s),I(o)&gt;
           is in IEXT(I(p))<br/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -460,7 +460,7 @@
       </tr>
 
       <tr>
-        <td class="semantictable">if E is an IRI then I(E) = IS(E)</td>
+        <td class="semantictable">if E is an IRI, then I(E) = IS(E)</td>
       </tr>
 
       <tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -406,7 +406,7 @@
               set of sets of pairs &lt; x, y &gt; with x and y in IR .</p>
         <p>4. A mapping IS from IRIs into (IR union IP)</p>
         <p>5. A partial mapping IL from literals into IR </p>
-        <p>6. A partial injective mapping RE from IR x IP x IR into IR, called the interpretation of triple terms. </p>
+        <p>6. An injective mapping RE from IR x IP x IR into IR, called the interpretation of triple terms. </p>
        </td>
     </tr>
   </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -464,8 +464,8 @@
       </tr>
 
       <tr>
-        <td class="semantictable">if E is a triple term then I(E) = RE(I(E.s), I(E.p), I(E.o))<br/>
-        where E.s, E.p, E.o are the first, second, and third components of E respectively</td>
+        <td class="semantictable">if E is a triple term, then I(E) = RE(I(E.s), I(E.p), I(E.o)),<br/>
+        where E.s, E.p, E.o are the first, second, and third components of E, respectively</td>
       </tr>
 
       <tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -465,7 +465,7 @@
 
       <tr>
         <td class="semantictable">if E is a ground triple term, then I(E) = RE(I(E.s), I(E.p), I(E.o)),<br/>
-        where E.s, E.p, E.o are the first, second, and third components of E, respectively</td>
+        where E.s, E.p, and E.o are the first, second, and third components of E, respectively</td>
       </tr>
 
       <tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -406,6 +406,7 @@
               set of sets of pairs &lt; x, y &gt; with x and y in IR .</p>
         <p>4. A mapping IS from IRIs into (IR union IP)</p>
         <p>5. A partial mapping IL from literals into IR </p>
+        <p>6. A partial injective mapping RE from IR x IP x IR into IR, called the interpretation of triple terms. </p>
        </td>
     </tr>
   </table>
@@ -460,6 +461,11 @@
 
       <tr>
         <td class="semantictable">if E is an IRI then I(E) = IS(E)</td>
+      </tr>
+
+      <tr>
+        <td class="semantictable">if E is a triple term then I(E) = RE(I(E.s), I(E.p), I(E.o))<br/>
+        where E.s, E.p, E.o are the first, second, third component of E respectively</td>
       </tr>
 
       <tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -464,7 +464,7 @@
       </tr>
 
       <tr>
-        <td class="semantictable">if E is a triple term, then I(E) = RE(I(E.s), I(E.p), I(E.o)),<br/>
+        <td class="semantictable">if E is a ground triple term, then I(E) = RE(I(E.s), I(E.p), I(E.o)),<br/>
         where E.s, E.p, E.o are the first, second, and third components of E, respectively</td>
       </tr>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -465,7 +465,7 @@
 
       <tr>
         <td class="semantictable">if E is a triple term then I(E) = RE(I(E.s), I(E.p), I(E.o))<br/>
-        where E.s, E.p, E.o are the first, second, third component of E respectively</td>
+        where E.s, E.p, E.o are the first, second, and third components of E respectively</td>
       </tr>
 
       <tr>


### PR DESCRIPTION
I have added the simple semantics as defined in the [liberal baseline](https://github.com/w3c/rdf-star-wg/wiki/RDF-star-%22liberal-baseline%22).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/franconi/rdf-semantics-fork-enrico/pull/68.html" title="Last updated on Jan 24, 2025, 4:29 PM UTC (842c87d)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/68/a9d9890...franconi:842c87d.html" title="Last updated on Jan 24, 2025, 4:29 PM UTC (842c87d)">Diff</a>