### PR TITLE
fix typo in explanatory text around simple interpretations

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -435,7 +435,7 @@
     is a set of pairs which identify the arguments for which the property is true,
     that is, a binary relational extension.</p>
 
-  <p>The distinction between IR and IL will become significant below when the semantics of datatypes are defined.
+  <p>The distinction between IS and IL will become significant below when the semantics of datatypes are defined.
     IL is allowed to be partial because some literals may fail to have a referent. </p>
 
   <p class="technote">It is conventional to map a relation name to a relational extension directly.


### PR DESCRIPTION
Fixes issue #58


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/73.html" title="Last updated on Jan 24, 2025, 4:48 PM UTC (0eee8da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/73/689618b...0eee8da.html" title="Last updated on Jan 24, 2025, 4:48 PM UTC (0eee8da)">Diff</a>