### PR TITLE
Definition: Use 'ill-typed' and 'value space' from RDF Concepts

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -774,11 +774,12 @@
     If the literal string is not in the lexical space,
     so that the lexical-to-value mapping gives no value for the literal string,
     then the literal has no referent.
-    The <dfn>value space</dfn> of a datatype is the range of the <a>lexical-to-value mapping</a>.
+    The <dfn data-cite="RDF12-CONCEPTS#dfn-value-space">value space</dfn> of a
+    datatype is the range of the <a>lexical-to-value mapping</a>.
     Every literal with that type either <a>denotes</a> a value in the value space of the type,
     or fails to denote at all.
-    An  <dfn>ill-typed</dfn> literal is one whose datatype IRI is <a>recognized</a>,
-    but whose
+    An <dfn data-cite="RDF12-CONCEPTS#dfn-ill-typed">ill-typed</dfn> literal
+    is one whose datatype IRI is <a>recognized</a>, but whose
     <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
     is assigned no value by the <a>lexical-to-value mapping</a>
     for that datatype.</p>


### PR DESCRIPTION
RDF Concepts uses ill-typed and so might others docs.
ill-typed should be in RDF Concepts like other defns in the this section.

See https://github.com/w3c/rdf-concepts/pull/153


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/75.html" title="Last updated on Jan 31, 2025, 9:33 PM UTC (cf4e3ff)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/75/8fe2785...cf4e3ff.html" title="Last updated on Jan 31, 2025, 9:33 PM UTC (cf4e3ff)">Diff</a>