### PR TITLE
remove partial in description of L2V

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -761,7 +761,7 @@
     The exception is <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
     which have two syntactic components, a string and a language tag,
     and are assigned the type <code>rdf:langString</code>.
-    A datatype is understood to define a partial mapping, 
+    A datatype is understood to define a mapping, 
     called the
     <span id="dfn-lexical-to-value-mapping"><!-- refer to RDF Concepts term --></span>
     <dfn data-cite="RDF12-CONCEPTS#dfn-lexical-to-value-mapping">lexical-to-value mapping</dfn>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -780,8 +780,9 @@
     An  <dfn>ill-typed</dfn> literal is one whose datatype IRI is <a>recognized</a>,
     but whose
     <a data-cite="RDF12-CONCEPTS#dfn-lexical-form">lexical form</a>
-    is assigned no value by the <a>lexical-to-value mapping</a>
-    for that datatype.</p>
+    is not in the lexical space of the datatype identified by that IRI and
+    thus is not in the domain of the <a>lexical-to-value mapping</a>
+    of that datatype.</p>
 
   <p>RDF processors are not required to <a>recognize</a> any datatype IRIs other than
     <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>


### PR DESCRIPTION
Fixes #66


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/77.html" title="Last updated on Feb 1, 2025, 12:29 PM UTC (cd1aaed)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/77/8fe2785...cd1aaed.html" title="Last updated on Feb 1, 2025, 12:29 PM UTC (cd1aaed)">Diff</a>