### PR TITLE
remove the only minor change comment in status

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -113,7 +113,6 @@
   <p>This document is part of RDF 1.2 document suite.
     This is a revision of the 2014 Semantics specification for RDF
     [[RDF11-MT]] and supersedes that document.
-    The technical content of the document is unchanged, only minor editorial changes have been made.
   </p>
 
   <section id="related" data-include="./common/related.html"></section>


### PR DESCRIPTION
Partial fix for #79


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/81.html" title="Last updated on Feb 6, 2025, 6:46 PM UTC (5706c59)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/81/53b171f...5706c59.html" title="Last updated on Feb 6, 2025, 6:46 PM UTC (5706c59)">Diff</a>