### PR TITLE
make technical uses of name refer to the definition

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -225,7 +225,7 @@
       when we wish to refer to such an externally defined naming relationship,
       we will use the word <dfn class="no-export lint-ignore" data-local-lt="identified">identify</dfn> and its cognates.
       For example, the fact that the IRI <code>http://www.w3.org/2001/XMLSchema#decimal</code>
-      is widely used as the name of a datatype described in the XML Schema document [[XMLSCHEMA11-2]]
+      is widely used as the <a>name</a> of a datatype described in the XML Schema document [[XMLSCHEMA11-2]]
       might be described by saying that the IRI <em>identifies</em> that datatype.
       If an IRI identifies something it may or may not denote it in a given interpretation,
       depending on how the semantics is specified.
@@ -456,10 +456,10 @@
   <p>The distinction between IS and IL will become significant below when the semantics of datatypes are defined.
     IL is allowed to be partial because some literals may fail to have a referent. </p>
 
-  <p class="technote">It is conventional to map a relation name to a relational extension directly.
-    This however presumes that the vocabulary is segregated into relation names and individual names,
+  <p class="technote">It is conventional to map a relation <a>name</a> to a relational extension directly.
+    This however presumes that the vocabulary is segregated into relation <a>name</a>s and individual <a>name</a>s,
     and RDF makes no such assumption.
-    Moreover, RDF allows an IRI to be used as a relation name applied to itself as an argument.
+    Moreover, RDF allows an IRI to be used as a relation <a>name</a> applied to itself as an argument.
     Such self-application structures are used in RDFS, for example.
     The use of the IEXT mapping to distinguish the relation as an object from its relational extension
     accommodates both of these requirements.
@@ -734,7 +734,7 @@
     sk(G) <a>simply entails</a> H if and only if G <a>simply entails</a> H.</p>
 
   <p>The second property means that a graph is not logically <a>equivalent</a> to its skolemization.
-    Nevertheless, they are in a strong sense almost interchangeable, as shown the next two properties. The third property means that even when conclusions are drawn from the skolemized graph which do contain the new vocabulary, these will exactly mirror what could have been derived from the original graph with the original blank nodes in place. The replacement of blank nodes by IRIs does not effectively alter what can be validly derived from the graph, other than by giving new names to what were formerly anonymous entities. The fourth property, which is a consequence of the third, clearly shows that in some sense  a skolemization of G can "stand in for" G as far as entailments are concerned. Using sk(G) instead of G will not affect any entailments which do not involve the new skolem vocabulary.  </p>
+    Nevertheless, they are in a strong sense almost interchangeable, as shown the next two properties. The third property means that even when conclusions are drawn from the skolemized graph which do contain the new vocabulary, these will exactly mirror what could have been derived from the original graph with the original blank nodes in place. The replacement of blank nodes by IRIs does not effectively alter what can be validly derived from the graph, other than by giving new <a>name</a>s to what were formerly anonymous entities. The fourth property, which is a consequence of the third, clearly shows that in some sense  a skolemization of G can "stand in for" G as far as entailments are concerned. Using sk(G) instead of G will not affect any entailments which do not involve the new skolem vocabulary.  </p>
 
 </section>
 
@@ -771,7 +771,7 @@
     a unique datatype wherever it occurs.
     RDF processors which are not able to determine which datatype is identified by an IRI
     cannot <a>recognize</a> that IRI,
-    and should treat any literals with that IRI as their datatype IRI as unknown names.</p>
+    and should treat any literals with that IRI as their datatype IRI as unknown <a>name</a>s.</p>
 
   <p>RDF literals and datatypes are fully described in
     <a data-cite="RDF12-CONCEPTS#section-Datatypes">Section 5</a> of [[!RDF12-CONCEPTS]].
@@ -1584,7 +1584,7 @@
   <!--
   <p>An RDF <a data-cite="RDF12-CONCEPTS#section-dataset">dataset</a> (see [[!RDF12-CONCEPTS]])
     is a finite set of RDF graphs each paired with an IRI or blank node called the <strong>graph name</strong>,
-    plus a <strong>default graph</strong>, without a name.
+    plus a <strong>default graph</strong>, without a <a>name</a>.
     Graphs in a single dataset may share blank nodes.
     The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
     to allow queries to be directed against particular graphs.</p>
@@ -1594,7 +1594,7 @@
     defined in RDF Concepts [[!RDF12-CONCEPTS]],
     package up zero or more named RDF graphs along with a single unnamed, default RDF graph.
     The graphs in a single dataset may share blank nodes.
-    The association of graph name IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
+    The association of graph <a>name</a> IRIs with graphs is used by SPARQL [[?SPARQL12-QUERY]]
     to allow queries to be directed against particular graphs.</p>
 
   <p>Graph names in a dataset may denote something other than the graph they are paired with.
@@ -1615,7 +1615,7 @@
   <p>Other <a>semantic extension</a>s and <a>entailment regime</a>s MAY place further semantic conditions and restrictions on RDF datasets,
     just as with RDF graphs.
     One such extension, for example, could set up a modal-like interpretation structure so that entailment
-    between datasets would require RDF graph entailments between the graphs with the same name
+    between datasets would require RDF graph entailments between the graphs with the same <a>name</a>
     (adding in empty graphs as required).</p>
 
   <table>
@@ -1853,7 +1853,7 @@
 
   <p>Basically, it is only necessary for an interpretation structure to interpret the <a>names</a>
     actually used in the graphs whose entailment is being considered, and to consider interpretations
-    whose universes are at most as big as the number of names and blank nodes in the graphs.
+    whose universes are at most as big as the number of <a>name</a>s and blank nodes in the graphs.
     More formally, we can define a <dfn>pre-interpretation</dfn> over a <a>vocabulary</a> V to be a structure I
     similar to a <a>simple interpretation</a> but with a mapping only from V to its universe IR.
     Then when determining whether G entails E, consider only pre-interpretations over the finite vocabulary
@@ -1995,7 +1995,7 @@
     <p>and suppose that IRI <code>ex:graph1</code> is used to <a>identify</a> this graph.
       Exactly how this identification is achieved is external to the RDF model,
       but it might be by the IRI resolving to a concrete syntax document describing the graph,
-      or by the IRI being the associated name of a named graph in a dataset.
+      or by the IRI being the associated <a>name</a> of a named graph in a dataset.
       Assuming that the IRI can be used to denote the triple,
       then the reification vocabulary allows us to describe the first graph in another graph:</p>
 


### PR DESCRIPTION
Fixes part of #78


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/82.html" title="Last updated on Feb 6, 2025, 7:14 PM UTC (0f17392)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/82/53b171f...0f17392.html" title="Last updated on Feb 6, 2025, 7:14 PM UTC (0f17392)">Diff</a>