### PR TITLE
add P&S sections pointing to Concepts

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2247,8 +2247,10 @@
 </section>
 <section id="security" class="informative appendix">
   <h2>Security Considerations (Informative)</h2>
-
-  See <a data-cite="RDF12-CONCEPTS#security">Security Considerations</a> in [[!RDF12-CONCEPTS]].
+  <p>
+    See <a data-cite="RDF12-CONCEPTS#security">Security Considerations</a> in [[RDF12-CONCEPTS]].
+  </p>
+</section>
 
 <section id="Acknowledgments" class="informative appendix" >
   <h2>Acknowledgments</h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -2239,6 +2239,16 @@
 
 </section>
 
+<section id="privacy" class="informative appendix">
+  <h2>Privacy Considerations (Informative)</h2>
+
+  See <a data-cite="RDF12-CONCEPTS#privacy">Privacy Considerations</a> in [[!RDF12-CONCEPTS]].
+
+<section id="security" class="informative appendix">
+  <h2>Security Considerations (Informative)</h2>
+
+  See <a data-cite="RDF12-CONCEPTS#security">Security Considerations</a> in [[!RDF12-CONCEPTS]].
+
 <section id="Acknowledgments" class="informative appendix" >
   <h2>Acknowledgments</h2>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -2241,9 +2241,10 @@
 
 <section id="privacy" class="informative appendix">
   <h2>Privacy Considerations (Informative)</h2>
-
-  See <a data-cite="RDF12-CONCEPTS#privacy">Privacy Considerations</a> in [[!RDF12-CONCEPTS]].
-
+  <p>
+    See <a data-cite="RDF12-CONCEPTS#privacy">Privacy Considerations</a> in [[RDF12-CONCEPTS]].
+  </p>
+</section>
 <section id="security" class="informative appendix">
   <h2>Security Considerations (Informative)</h2>
 


### PR DESCRIPTION
See https://lists.w3.org/Archives/Public/public-rdf-star-wg/2025Feb/0011.html


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/89.html" title="Last updated on Feb 20, 2025, 8:33 PM UTC (b4fe1e0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/89/53b171f...b4fe1e0.html" title="Last updated on Feb 20, 2025, 8:33 PM UTC (b4fe1e0)">Diff</a>