### PR TITLE
A formal background to unify triples and triple terms

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1490,6 +1490,12 @@
             <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code><br/>
             yyy <code>rdf:type rdfs:Resource .</code></td>
           </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs14</dfn></td>
+            <td class="othertable">xxx yyy <<(aaa bbb ccc)>> <code></code></td>
+            <td class="othertable">xxx yyy _:nnn <code>.</code><br/>
+            _:nnn <code>rdf:type rdfs:Proposition .</code></td>
+          </tr>
         </tbody>
       </table>
 
@@ -1598,11 +1604,21 @@
           ex:d ex:a ex:e .</code></td>
        <td class="othertable"><code>ex:d rdf:type ex:c .</code> </td>
       </tr>
+
+      <tr>
+        <th> </th>
+        <th>RDFS entails</th>
+      </tr>
+
+      <tr>
+        <td class="othertable"><code>ex:a ex:b ex:c .</code></td>
+       <td class="othertable"><code><<(ex:a ex:b ex:c)>> rdf:type rdfs:Proposition .</code> </td>
+      </tr>
     </tbody>
   </table>
 
-  <p>Both of these can be handled by allowing the rules to apply to a generalization of the RDF syntax
-    in which literals may occur in subject position and blank nodes may occur in predicate position.</p>
+  <p>These examples can be handled by allowing the rules to apply to a generalization of the RDF syntax
+    in which literals and triple terms may occur in subject position and blank nodes may occur in predicate position.</p>
 
   <!--<p>Define a <dfn>generalized RDF triple</dfn> to be a triple &lt;x, y, z&gt; where x and z can be an IRI, a blank node or a literal, and y can be an IRI or a blank node; and extend this to the rest of RDF, so that a generalized RDF graph is a set of generalized RDF triples. -->
 
@@ -1680,6 +1696,28 @@
 
   <p>As noted earlier, detecting datatype entailment for larger sets of datatype IRIs
     requires attention to idiosyncratic properties of the particular datatypes.</p>
+    
+  <p>
+  The complete entailment pattern for generalized RDF considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following, which supersedes the entailment pattern <a>rdfs14<a/>:
+    <table>
+    <caption>RDFS-T entailment pattern.</caption>
+    <tbody>
+      <tr>
+        <th > </th>
+        <th ><strong>if S contains</strong></th>
+        <th ><strong>then S RDFS entails</strong></th>
+      </tr>
+      <tr >
+        <td class="othertable"><dfn>Grdfs14</dfn></td>
+        <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code><br/>
+        yyy <code>rdf:type rdf:Property .</code><br/>
+        zzz <code>rdf:type rdfs:Resource .</code><br/>
+        </td>
+        <td class="othertable"><code><<(xxx yyy zzz)>> rdf:type rdfs:Proposition .</code></td>
+      </tr>
+    </tbody>
+    </table>
+  </p>
 
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1521,11 +1521,11 @@
         </tbody>
       </table>
 
-      <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph &emdash;</p>
+      <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph &mdash;</p>
 
       <p><code>ex:a ex:b <<( ex:c ex:d <<(ex:e ex:f ex:g)>> )>> .</code></p>
 
-      <p>&emdash; RDFS entails &emdash;</p>
+      <p>&mdash; RDFS entails &mdash;</p>
 
       <p><code>ex:a ex:b <<( ex:c ex:d _:b1 )>> .<br/>
                ex:a ex:b _:b2 .<br/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -266,7 +266,7 @@
     <p/>
 
     <p>Suppose that M is a functional mapping from a set of blank
-      nodes to some set of RDF terms. Any graph obtained
+      nodes to some set of [=RDF terms=]. Any graph obtained
       from a graph G by replacing some or all of the blank nodes N appearing in G by M(N) is
       an <dfn>instance</dfn> of G. Any graph is an instance of itself,
       an instance of an instance of G is an instance of G,

--- a/spec/index.html
+++ b/spec/index.html
@@ -1700,7 +1700,7 @@
     requires attention to idiosyncratic properties of the particular datatypes.</p>
     
   <p>
-  The complete entailment pattern for generalized RDF, considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
+  The complete entailment pattern for generalized RDF with [=symmetric RDF triple=]s, considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
     <table>
     <caption>RDFS-T entailment pattern.</caption>
     <tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -300,8 +300,8 @@
     <p>is lean. <a>Ground</a> graphs are lean. </p>
     
     <p>
-    A RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G) defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
-    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, object appears in G.
+    An RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G), defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
+    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, and object appears in G.
     <p/>
 
   <section id="unions_merges">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1282,7 +1282,7 @@
         rdfs:isDefinedBy rdfs:subPropertyOf rdfs:seeAlso .<br/>
         <br/>
 
-        rdf:reifies rdf:range rdfs:Proposition .<br/>
+        rdf:reifies rdfs:range rdfs:Proposition .<br/>
         <br/>
         
         rdfs:Datatype rdfs:subClassOf rdfs:Class .<br/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1241,7 +1241,12 @@
     </tr>
     <tr>
     <td class="semantictable" id="rdfssemcond11"><p>If
-      exist x,y,z such that RE(x,z,y)=r, or exists x such that &lt; x,r &gt; is in IEXT(I(<code>rdf:reifies</code>)), <br/> then &lt; r,I(<code>rdfs:Proposition</code>)&gt; is in IEXT(I(<code>rdf:type</code>))</p></td>
+      exist x,y,z such that RE(x,z,y)=r, or 
+      exists x such that &lt; x,r &gt; 
+        is in IEXT(I(<code>rdf:reifies</code>)), 
+      <br/> 
+      then &lt; r,I(<code>rdfs:Proposition</code>)&gt; 
+        is in IEXT(I(<code>rdf:type</code>))</p></td>
     </tr>
   </table>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1713,7 +1713,9 @@
     requires attention to idiosyncratic properties of the particular datatypes.</p>
     
   <p>
-  The complete entailment pattern for generalized RDF with [=symmetric RDF triple=]s, considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
+  The complete entailment pattern for generalized RDF with [=symmetric RDF triples=],
+  considering that, according to the semantics, the denotation of triple terms should
+  be of type <code>rdfs:Proposition</code>, is the following:
     <table>
     <caption>RDFS-T entailment pattern.</caption>
     <tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -274,12 +274,15 @@
     <p/>
 
     <p>Suppose that M is a functional mapping from a set of blank
-      nodes to some set of [=RDF terms=]. Any graph obtained
+      nodes to some set of RDF terms. Any graph obtained
       from a graph G by replacing some or all of the blank nodes N appearing in G by M(N) is
       an <dfn>instance</dfn> of G. Any graph is an instance of itself,
       an instance of an instance of G is an instance of G,
       and if H is an instance of G then every triple in H is an instance of at least one triple
       in G.</p>
+      
+      <p class="issue">the defined term "RDF term" is not accessible from outside this document, which is a problem (RDF semantics, and probably other specs, need to reference it). There are other definitions in this spec that need to be exported - see <a href="https://github.com/w3c/rdf-concepts/issues/152">issue #152</a> in RDF-concepts.</p>
+
 
     <p>An <dfn class="no-export lint-ignore">instance with respect to</dfn> a vocabulary
       V is an <a>instance</a> in which all the
@@ -1106,7 +1109,7 @@
 
           <tr>
              <td class="othertable"><dfn>rdfD2</dfn></td>
-             <td class="othertable">xxx aaa yyy <code></code></td>
+             <td class="othertable">xxx aaa yyy <code>.</code></td>
              <td class="othertable">aaa <code>rdf:type rdf:Property .</code> </td>
           </tr>
         </tbody>
@@ -1504,16 +1507,16 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs4</dfn></td>
-            <td class="othertable">xxx aaa yyy <code></code></td>
+            <td class="othertable">xxx aaa yyy <code>.</code></td>
             <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code><br/>
             yyy <code>rdf:type rdfs:Resource .</code></td>
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
-            <td class="othertable">xxx yyy &lt;&lt;(aaa bbb ccc)>> <code></code></td>
-            <td class="othertable">the graph S with the appearance replaced with <br/>
-            xxx yyy _:nnn <code></code><br/>
-            _:nnn <code>rdf:type rdfs:Proposition .</code></td>
+            <td class="othertable">xxx yyy &lt;&lt;(aaa bbb ccc)>> <code>.</code></td>
+            <td class="othertable"><ul><li>the graph S with the appearance replaced with<br/>
+            xxx yyy _:nnn <code></code></li>
+            <li>_:nnn <code>rdf:type rdfs:Proposition .</code></li></ul></td>
           </tr>
         </tbody>
       </table>
@@ -1739,6 +1742,9 @@
     </tbody>
     </table>
   </p>
+  
+  <p class="issue" data-number="76">We don't have a completeness proof for the RDFS entailment rules (yet).</p>
+
 
 </section>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -113,7 +113,7 @@
   <p>This document is part of RDF 1.2 document suite.
     This is a revision of the 2014 Semantics specification for RDF
     [[RDF11-MT]] and supersedes that document.
-    The technical content of the document is unchanged, only minor editorial changes have been made.</a>
+    The technical content of the document is unchanged, only minor editorial changes have been made.
   </p>
 
   <section id="related" data-include="./common/related.html"></section>
@@ -261,7 +261,7 @@
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
     <p>Suppose that M is a functional mapping from a set of blank
-      nodes to some set of RTD terms. Any graph obtained
+      nodes to some set of RDF terms. Any graph obtained
       from a graph G by replacing some or all of the blank nodes N in G by M(N) is
       an <dfn>instance</dfn> of G. Any graph is an instance of itself,
       an instance of an instance of G is an instance of G,
@@ -1230,7 +1230,7 @@
       x is in ICEXT(I(<code>rdfs:Datatype</code>)) then <span >&lt; x,
       I(<code>rdfs:Literal</code>) &gt; is in IEXT(I(<code>rdfs:subClassOf</code>))</span></p></td>
     </tr>
-    
+    <tr>
     <td class="semantictable" id="rdfssemcond11"><p>If
       exist x,y,z such that RE(x,z,y)=r, or exists x such that &lt; x,r &gt; is in IEXT([I+A](<code>rdf:reifies</code>)), <br/> then &lt; r,[I+A](<code>rdfs:Proposition</code>)&gt; is in IEXT([I+A](<code>rdf:type</code>))</p></td>
     </tr>
@@ -1492,7 +1492,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
-            <td class="othertable">xxx yyy <<(aaa bbb ccc)>> <code></code></td>
+            <td class="othertable">xxx yyy &lt;&lt;(aaa bbb ccc)>> <code></code></td>
             <td class="othertable">the graph S with the appearance replaced with <br/>
             xxx yyy _:nnn <code></code><br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
@@ -1613,7 +1613,7 @@
 
       <tr>
         <td class="othertable"><code>ex:a ex:b ex:c .</code></td>
-       <td class="othertable"><code><<(ex:a ex:b ex:c)>> rdf:type rdfs:Proposition .</code> </td>
+       <td class="othertable"><code>&lt;&lt;(ex:a ex:b ex:c)>> rdf:type rdfs:Proposition .</code> </td>
       </tr>
     </tbody>
   </table>
@@ -1714,7 +1714,7 @@
         yyy <code>rdf:type rdf:Property .</code><br/>
         zzz <code>rdf:type rdfs:Resource .</code><br/>
         </td>
-        <td class="othertable"><code><<(xxx yyy zzz)>> rdf:type rdfs:Proposition .</code></td>
+        <td class="othertable"><code>&lt;&lt;(xxx yyy zzz)>> rdf:type rdfs:Proposition .</code></td>
       </tr>
     </tbody>
     </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -974,6 +974,7 @@
         rdf:subject rdf:type rdf:Property .<br/>
         rdf:predicate rdf:type rdf:Property .<br/>
         rdf:object rdf:type rdf:Property .<br/>
+        rdf:reifies rdf:type rdf:Property .<br/>
         rdf:first rdf:type rdf:Property .<br/>
         rdf:rest rdf:type rdf:Property .<br/>
         rdf:value rdf:type rdf:Property .<br/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1521,6 +1521,16 @@
         </tbody>
       </table>
 
+      <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph:</p>
+
+      <p><code>ex:a ex:b <<( ex:c ex:d <<(ex:e ex:f ex:g)>> )>> .</code></p>
+
+      <p>RDFS entails:</p>
+
+      <p><code>ex:a ex:b <<( ex:c ex:d _:b1 )>> .<br/>
+               ex:a ex:b _:b2 .<br/>
+               _:b1 rdf:type rdfs:Proposition .<br/>
+               _:b2 rdf:type rdfs:Proposition .</code></p>
 
       <p>RDFS provides for several new ways to be <a>unsatisfiable</a> recognizing D.
         For example, the following graph is RDFS unsatisfiable recognizing {<code>xsd:integer</code>, <code>xsd:boolean</code>}:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -261,7 +261,7 @@
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
     <p>Suppose that M is a functional mapping from a set of blank
-      nodes to some set of literals, blank nodes and IRIs. Any graph obtained
+      nodes to some set of RTD terms. Any graph obtained
       from a graph G by replacing some or all of the blank nodes N in G by M(N) is
       an <dfn>instance</dfn> of G. Any graph is an instance of itself,
       an instance of an instance of G is an instance of G,
@@ -298,6 +298,11 @@
     </pre>
 
     <p>is lean. <a>Ground</a> graphs are lean. </p>
+    
+    <p>
+    A RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G) defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
+    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, object appears in G.
+    <p/>
 
   <section id="unions_merges">
     <h3>Shared blank nodes, unions and merges</h3>
@@ -936,7 +941,7 @@
       </tr>
 
       <tr>
-        <td ><code>rdf:type rdf:subject rdf:predicate rdf:object
+        <td ><code>rdf:type rdf:reifies rdf:subject rdf:predicate rdf:object
           rdf:first rdf:rest rdf:value rdf:nil
           rdf:List rdf:langString rdf:Property rdf:_1 rdf:_2
            ...</code></td>
@@ -1060,6 +1065,7 @@
 
       <p>In addition, the first RDF semantic condition justifies the following entailment pattern:</p>
 
+<!-- 
       <table>
         <tbody>
           <tr>
@@ -1071,6 +1077,23 @@
           <tr>
              <td class="othertable"><dfn>rdfD2</dfn></td>
              <td class="othertable">xxx aaa yyy <code>.</code></td>
+             <td class="othertable">aaa <code>rdf:type rdf:Property .</code> </td>
+          </tr>
+        </tbody>
+      </table>
+ -->
+ 
+       <table>
+        <tbody>
+          <tr>
+            <th></th>
+            <th><strong>if the triple or triple term <a>appears in</a> S</strong></th>
+            <th><strong>then S RDF entails, recognizing D</strong></th>
+          </tr>
+
+          <tr>
+             <td class="othertable"><dfn>rdfD2</dfn></td>
+             <td class="othertable">xxx aaa yyy <code></code></td>
              <td class="othertable">aaa <code>rdf:type rdf:Property .</code> </td>
           </tr>
         </tbody>
@@ -1118,6 +1141,7 @@
       <tr>
         <td ><code>rdfs:domain rdfs:range rdfs:Resource rdfs:Literal
         rdfs:Datatype rdfs:Class rdfs:subClassOf rdfs:subPropertyOf
+        rdfs:Proposition 
         rdfs:member rdfs:Container rdfs:ContainerMembershipProperty
         rdfs:comment rdfs:seeAlso rdfs:isDefinedBy
         rdfs:label</code></td>
@@ -1206,6 +1230,10 @@
       x is in ICEXT(I(<code>rdfs:Datatype</code>)) then <span >&lt; x,
       I(<code>rdfs:Literal</code>) &gt; is in IEXT(I(<code>rdfs:subClassOf</code>))</span></p></td>
     </tr>
+    
+    <td class="semantictable" id="rdfssemcond11"><p>If
+      exist x,y,z such that RE(x,z,y)=r, or exists x such that &lt; x,r &gt; is in IEXT([I+A](<code>rdf:reifies</code>)), <br/> then &lt; r,[I+A](<code>rdfs:Proposition</code>)&gt; is in IEXT([I+A](<code>rdf:type</code>))</p></td>
+    </tr>
   </table>
 
   <table id="RDFS_axiomatic_triples">
@@ -1253,6 +1281,9 @@
         rdfs:isDefinedBy rdfs:subPropertyOf rdfs:seeAlso .<br/>
         <br/>
 
+        rdf:reifies rdf:range rdfs:Proposition .<br/>
+        <br/>
+        
         rdfs:Datatype rdfs:subClassOf rdfs:Class .<br/>
         <br/>
         rdf:_1 rdf:type rdfs:ContainerMembershipProperty .<br/>
@@ -1261,7 +1292,8 @@
         rdf:_2 rdf:type rdfs:ContainerMembershipProperty .<br/>
         rdf:_2 rdfs:domain rdfs:Resource .<br/>
         rdf:_2 rdfs:range rdfs:Resource . <br/>
-        </code>... <br/> </td>
+        </code>... <br/> 
+        </td>
     </tr>
   </table>
 
@@ -1392,16 +1424,6 @@
             <td class="othertable">zzz <code>rdf:type</code> xxx <code>.</code></td>
           </tr>
           <tr >
-            <td class="othertable"><dfn>rdfs4a</dfn></td>
-            <td class="othertable">xxx aaa yyy <code>.</code></td>
-            <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code></td>
-          </tr>
-          <tr >
-            <td class="othertable"><dfn>rdfs4b</dfn></td>
-            <td class="othertable">xxx aaa yyy<code>.</code></td>
-            <td class="othertable">yyy <code>rdf:type rdfs:Resource .</code></td>
-          </tr>
-          <tr >
             <td class="othertable"><dfn>rdfs5</dfn></td>
             <td class="othertable"> xxx <code>rdfs:subPropertyOf</code> yyy <code>.</code><br />
                 yyy <code>rdfs:subPropertyOf</code> zzz <code>.</code></td>
@@ -1452,6 +1474,25 @@
           </tr>
         </tbody>
       </table>
+      
+      <p/>
+      
+      <table id="rdfs_entailment_patterns_recursive">
+        <tbody>
+          <tr>
+            <th ></th>
+            <th >If the triple or triple term <a>appears in</a> S:</th>
+            <th >then S RDFS <a>entails recognizing D</a>:</th>
+          </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs4</dfn></td>
+            <td class="othertable">xxx aaa yyy <code></code></td>
+            <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code><br/>
+            yyy <code>rdf:type rdfs:Resource .</code></td>
+          </tr>
+        </tbody>
+      </table>
+
 
       <p>RDFS provides for several new ways to be <a>unsatisfiable</a> recognizing D.
         For example, the following graph is RDFS unsatisfiable recognizing {<code>xsd:integer</code>, <code>xsd:boolean</code>}:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1699,7 +1699,7 @@
     requires attention to idiosyncratic properties of the particular datatypes.</p>
     
   <p>
-  The complete entailment pattern for generalized RDF considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
+  The complete entailment pattern for generalized RDF, considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
     <table>
     <caption>RDFS-T entailment pattern.</caption>
     <tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1233,7 +1233,7 @@
     </tr>
     <tr>
     <td class="semantictable" id="rdfssemcond11"><p>If
-      exist x,y,z such that RE(x,z,y)=r, or exists x such that &lt; x,r &gt; is in IEXT([I+A](<code>rdf:reifies</code>)), <br/> then &lt; r,[I+A](<code>rdfs:Proposition</code>)&gt; is in IEXT([I+A](<code>rdf:type</code>))</p></td>
+      exist x,y,z such that RE(x,z,y)=r, or exists x such that &lt; x,r &gt; is in IEXT(I(<code>rdf:reifies</code>)), <br/> then &lt; r,I(<code>rdfs:Proposition</code>)&gt; is in IEXT(I(<code>rdf:type</code>))</p></td>
     </tr>
   </table>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -265,7 +265,7 @@
     defined inductively as follows:
     (1) for each triple in the graph G,
         its subject, predicate, and object are in TM(G);
-    (2) for each triple term in TH(G),
+    (2) for each triple term in TM(G),
         its subject, predicate, and object are in TM(G).
     <br/><br/>
     A triple <b><i>appears in</i></b> a graph G

--- a/spec/index.html
+++ b/spec/index.html
@@ -1699,7 +1699,7 @@
     requires attention to idiosyncratic properties of the particular datatypes.</p>
     
   <p>
-  The complete entailment pattern for generalized RDF considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following, which supersedes the entailment pattern <a>rdfs14<a/>:
+  The complete entailment pattern for generalized RDF considering that, according to the semantics, the denotation of triple terms should be of type <code>rdfs:Proposition</code>, is the following:
     <table>
     <caption>RDFS-T entailment pattern.</caption>
     <tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -422,7 +422,7 @@
               set of sets of pairs &lt; x, y &gt; with x and y in IR .</p>
         <p>4. A mapping IS from IRIs into (IR union IP)</p>
         <p>5. A partial mapping IL from literals into IR </p>
-        <p>6. An injective mapping RE from IR x IP x IR into IR, called the interpretation of triple terms. </p>
+        <p>6. An injective mapping RE from IR x IP x IR into IR, called the denotation of triple terms. </p>
        </td>
     </tr>
   </table>
@@ -650,7 +650,7 @@
   </section>
 
   <section id="simple_entailment_properties" class="informative">
-    <h3>Properties of simple entailment (Informative)</h3>
+    <h3>Properties of simple entailment and satisfiability (Informative)</h3>
 
     <p>The properties described here apply only to simple entailment,
       not to extended notions of entailment introduced in later sections.
@@ -706,6 +706,24 @@
 
     <p class="fact"> If E contains an IRI which does not occur anywhere in S,
       then S does not simply entail E.</p>
+      
+    <p>The following semantic properties relate triple terms and triples asserted in a graph, and they introduce a general definition of satisfiability.<br/>
+    We define the <dfn>set of propositions</dfn> as follows:
+
+	<p class="fact"> The set of propositions in an interpretation I is IPR(I) = {&nbsp;&lt;x, y, z&gt;&#65372;x is in IR, y is in IP, z is in IR&nbsp;}; we observe that the propositions are exactly the domain of the RE mapping used to denote triple terms as resources. </p>
+
+	<p>We define the <dfn>set of facts</dfn> as follows:</p>
+
+	<p class="fact"> The set F of facts in an interpretation I is F(I) = {&nbsp;&lt;x, y, z&gt;&#65372;&lt;x, z&gt; is in IEXT(y)&nbsp;}; it is easy to see that the facts are the propositions which are true in the interpretation. </p>
+
+	<p>We define the <dfn>set of facts asserted by a graph G</dfn> as follows:</p>
+
+	<p class="fact"> The set of all facts asserted by a graph G with a blank node mapping A in an interpretation I is FEXT(G, I, A) = {&nbsp;&lt;&nbsp;[I+A](s), I(p), [I+A](o)&nbsp;&gt;&#65372;`s p o.` is in G&nbsp;}; given an interpretation and a graph, the asserted facts of the graph may not necessarily be among the facts of the interpretation.</p>
+	
+	<p>Given a mapping A, we introduce a <dfn>general definition of satisfiability</dfn> as follows:</p>
+
+	<p class="fact">Given an interpretation and a graph with a blank node mapping, the facts asserted by the graph are among the facts of the interpretation if and only if the interpretation (simply) satisfies the graph.</p>
+	
 
   </section>
 </section>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1521,11 +1521,11 @@
         </tbody>
       </table>
 
-      <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph:</p>
+      <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph &emdash;</p>
 
       <p><code>ex:a ex:b <<( ex:c ex:d <<(ex:e ex:f ex:g)>> )>> .</code></p>
 
-      <p>RDFS entails:</p>
+      <p>&emdash; RDFS entails &emdash;</p>
 
       <p><code>ex:a ex:b <<( ex:c ex:d _:b1 )>> .<br/>
                ex:a ex:b _:b2 .<br/>

--- a/spec/index.html
+++ b/spec/index.html
@@ -260,9 +260,14 @@
 
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
+    <p>
+    An RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G), defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
+    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, and object appears in G.
+    <p/>
+
     <p>Suppose that M is a functional mapping from a set of blank
       nodes to some set of RDF terms. Any graph obtained
-      from a graph G by replacing some or all of the blank nodes N in G by M(N) is
+      from a graph G by replacing some or all of the blank nodes N appearing in G by M(N) is
       an <dfn>instance</dfn> of G. Any graph is an instance of itself,
       an instance of an instance of G is an instance of G,
       and if H is an instance of G then every triple in H is an instance of at least one triple
@@ -299,11 +304,6 @@
 
     <p>is lean. <a>Ground</a> graphs are lean. </p>
     
-    <p>
-    An RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G), defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
-    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, and object appears in G.
-    <p/>
-
   <section id="unions_merges">
     <h3>Shared blank nodes, unions and merges</h3>
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1493,7 +1493,8 @@
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
             <td class="othertable">xxx yyy <<(aaa bbb ccc)>> <code></code></td>
-            <td class="othertable">xxx yyy _:nnn <code>.</code><br/>
+            <td class="othertable">the graph S with the appearance replaced with <br/>
+            xxx yyy _:nnn <code></code><br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>
         </tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1514,9 +1514,9 @@
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
             <td class="othertable">xxx yyy &lt;&lt;(aaa bbb ccc)>> <code>.</code></td>
-            <td class="othertable"><ul><li>the graph S with the appearance replaced with<br/>
-            xxx yyy _:nnn <code></code></li>
-            <li>_:nnn <code>rdf:type rdfs:Proposition .</code></li></ul></td>
+            <td class="othertable">the graph S with the appearance replaced with<br/>
+            xxx yyy _:nnn <code></code><br/><br/>
+            _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>
         </tbody>
       </table>

--- a/spec/index.html
+++ b/spec/index.html
@@ -261,8 +261,16 @@
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
     <p>
-    An RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G), defined inductively as follows: (1) for each triple in the graph G, its subject, predicate, and object are in TM(G); (2) for each triple term in TH(G), its subject, predicate, and object are in TM(G).<br/>
-    A triple <b><i>appears in</i></b> a graph G if it is in G or if the triple term composed by its subject, predicate, and object appears in G.
+    An RDF term <dfn>appears in</dfn> a graph G if it is in the set TM(G),
+    defined inductively as follows:
+    (1) for each triple in the graph G,
+        its subject, predicate, and object are in TM(G);
+    (2) for each triple term in TH(G),
+        its subject, predicate, and object are in TM(G).
+    <br/><br/>
+    A triple <b><i>appears in</i></b> a graph G
+    if it is in G or
+    if the triple term composed by its subject, predicate, and object appears in G.
     <p/>
 
     <p>Suppose that M is a functional mapping from a set of blank

--- a/spec/index.html
+++ b/spec/index.html
@@ -1096,7 +1096,7 @@
         <tbody>
           <tr>
             <th></th>
-            <th><strong>if the triple or triple term <a>appears in</a> S</strong></th>
+            <th><strong>if the triple <a>appears in</a> S</strong></th>
             <th><strong>then S RDF entails, recognizing D</strong></th>
           </tr>
 
@@ -1495,7 +1495,7 @@
         <tbody>
           <tr>
             <th ></th>
-            <th >If the triple or triple term <a>appears in</a> S:</th>
+            <th >If the triple <a>appears in</a> S:</th>
             <th >then S RDFS <a>entails recognizing D</a>:</th>
           </tr>
           <tr >


### PR DESCRIPTION
Added at the end of Section 5.3: 

- semantic properties relating triple terms and asserted triples, together with a general definition of (simple) satisfiability.

The terminology defined here should be used to support the unification of the terminology of triples, as per [issue #158](https://github.com/w3c/rdf-concepts/pull/158) in Concepts.
