### PR TITLE
Substitution function and entailment patterns rdfs14 and rdfD1

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1091,7 +1091,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfD1</dfn></td>
-            <td class="othertable">   ttt and <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
+            <td class="othertable">ttt and <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
                 for ddd in D</td>
             <td class="othertable">ttt [<code>"</code>sss<code>"^^</code>/_:nnn] <br/>
       _:nnn <code>rdf:type</code> ddd <code>.</code></td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1551,7 +1551,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
-            <td class="othertable">ttt and  &lt;&lt;(aaa bbb ccc)&gt;&gt; appears in ttt</td>
+            <td class="othertable">Any triple ttt such that  &lt;&lt;(aaa bbb ccc)&gt;&gt; appears in ttt</td>
             <td class="othertable">ttt [&lt;&lt;(aaa bbb ccc)>>/_:nnn]<br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1551,7 +1551,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
-            <td class="othertable">Any triple ttt such that  &lt;&lt;(aaa bbb ccc)&gt;&gt; appears in ttt</td>
+            <td class="othertable">Any triple ttt such that &lt;&lt;(aaa bbb ccc)&gt;&gt; appears in ttt</td>
             <td class="othertable">ttt [&lt;&lt;(aaa bbb ccc)>>/_:nnn]<br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>

--- a/spec/index.html
+++ b/spec/index.html
@@ -273,6 +273,16 @@
     if the triple term composed by its subject, predicate, and object appears in G.
     <p/>
 
+    <p>
+      For RDF terms t, x and y, we define the  <dfn>substitution mapping</dfn>, t[x/y] inductively as follows: 
+      (1) if  t=x, then t[x/y]=y;
+      (2) if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]=y);
+      (3) t[x/y]=t, else. 
+      <br/><br/>
+      For each triple (s,p,o), we set (s,p,o)[x/y]= (s[x/y],p[x/y],o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
+      <p/>
+
+
     <p>Suppose that M is a functional mapping from a set of blank
       nodes to some set of RDF terms. Any graph obtained
       from a graph G by replacing some or all of the blank nodes N appearing in G by M(N) is

--- a/spec/index.html
+++ b/spec/index.html
@@ -280,11 +280,12 @@
     For RDF terms t, x, and y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
   </p>
     <ol>
-    <li> if  t=x, then t[x/y]=y; </li>
-    <li> if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]);</li>
-    <li> else, t[x/y]=t. </li>
+    <li>If t = x, then t[x/y] = y.</li>
+    <li>If t = (s, p, o) and t &ne; x, then t[x/y] = (s[x/y], p[x/y], o[x/y]).</li>
+    <li>Else, t[x/y] = t.</li>
   </ol>
-    For each triple (s,p,o), we set (s,p,o)[x/y]= (s[x/y],p[x/y],o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
+  <p>
+    For each triple (s, p, o), we set (s, p, o)[x/y] = (s[x/y], p[x/y], o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
   </p>
 
 

--- a/spec/index.html
+++ b/spec/index.html
@@ -279,7 +279,7 @@
   <p>
     For RDF terms t, x, and y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
   </p>
-    <ol>
+  <ol>
     <li>If t = x, then t[x/y] = y.</li>
     <li>If t = (s, p, o) and t &ne; x, then t[x/y] = (s[x/y], p[x/y], o[x/y]).</li>
     <li>Else, t[x/y] = t.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1091,7 +1091,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfD1</dfn></td>
-            <td class="othertable">ttt and <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
+            <td class="othertable">Any triple ttt such that <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
                 for ddd in D</td>
             <td class="othertable">ttt [<code>"</code>sss<code>"^^</code>/_:nnn] <br/>
       _:nnn <code>rdf:type</code> ddd <code>.</code></td>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1497,7 +1497,7 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfs4</dfn></td>
-            <td class="othertable">ttt and xxx appears in ttt</td> 
+            <td class="othertable">Any triple ttt such that xxx appears in ttt</td> 
             <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code>
           </tr>
           <tr >

--- a/spec/index.html
+++ b/spec/index.html
@@ -280,7 +280,7 @@
     For RDF terms t, x and y, we define the  <dfn>substitution mapping</dfn>, t[x/y] inductively as follows: 
     <ol>
     <li> if  t=x, then t[x/y]=y; </li>
-    <li> if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]=y);</li>
+    <li> if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]);</li>
     <li> else, t[x/y]=t. </li>
   </ol>
     For each triple (s,p,o), we set (s,p,o)[x/y]= (s[x/y],p[x/y],o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.

--- a/spec/index.html
+++ b/spec/index.html
@@ -1093,7 +1093,7 @@
             <td class="othertable"><dfn>rdfD1</dfn></td>
             <td class="othertable">Any triple ttt such that <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
                 for ddd in D</td>
-            <td class="othertable">ttt [<code>"</code>sss<code>"^^</code>/_:nnn] <br/>
+            <td class="othertable">ttt [<code>"</code>sss<code>"^^</code>ddd/_:nnn] <br/>
       _:nnn <code>rdf:type</code> ddd <code>.</code></td>
           </tr>
         </tbody>

--- a/spec/index.html
+++ b/spec/index.html
@@ -281,8 +281,8 @@
   </p>
   <ol>
     <li>If t = x, then t[x/y] = y.</li>
-    <li>If t = (s, p, o) and t &ne; x, then t[x/y] = (s[x/y], p[x/y], o[x/y]).</li>
-    <li>Else, t[x/y] = t.</li>
+    <li>Otherwise, if t = (s, p, o), then t[x/y] = (s[x/y], p[x/y], o[x/y]).</li>
+    <li>Otherwise, t[x/y] = t.</li>
   </ol>
   <p>
     For each triple (s, p, o), we set (s, p, o)[x/y] = (s[x/y], p[x/y], o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.

--- a/spec/index.html
+++ b/spec/index.html
@@ -277,7 +277,8 @@
 
 
   <p>
-    For RDF terms t, x and y, we define the  <dfn>substitution mapping</dfn>, t[x/y] inductively as follows: 
+    For RDF terms t, x, and y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
+  </p>
     <ol>
     <li> if  t=x, then t[x/y]=y; </li>
     <li> if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]);</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1557,8 +1557,6 @@
           </tr>
         </tbody>
       </table>
-
-
       <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph &mdash;</p>
 
       <p><code>ex:a ex:b <<( ex:c ex:d <<(ex:e ex:f ex:g)>> )>> .</code></p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -271,16 +271,20 @@
     A triple <b><i>appears in</i></b> a graph G
     if it is in G or
     if the triple term composed by its subject, predicate, and object appears in G.
-    <p/>
+    </p>
 
-    <p>
-      For RDF terms t, x and y, we define the  <dfn>substitution mapping</dfn>, t[x/y] inductively as follows: 
-      (1) if  t=x, then t[x/y]=y;
-      (2) if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]=y);
-      (3) t[x/y]=t, else. 
-      <br/><br/>
-      For each triple (s,p,o), we set (s,p,o)[x/y]= (s[x/y],p[x/y],o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
-      <p/>
+
+
+
+  <p>
+    For RDF terms t, x and y, we define the  <dfn>substitution mapping</dfn>, t[x/y] inductively as follows: 
+    <ol>
+    <li> if  t=x, then t[x/y]=y; </li>
+    <li> if t = (s,p,o) and t &ne; x, then t[x/y]= (s[x/y], p[x/y], o[x/y]=y);</li>
+    <li> else, t[x/y]=t. </li>
+  </ol>
+    For each triple (s,p,o), we set (s,p,o)[x/y]= (s[x/y],p[x/y],o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
+  </p>
 
 
     <p>Suppose that M is a functional mapping from a set of blank
@@ -1085,9 +1089,9 @@
           </tr>
           <tr >
             <td class="othertable"><dfn>rdfD1</dfn></td>
-            <td class="othertable">   xxx aaa <code>"</code>sss<code>"^^</code>ddd <code>.</code> <br/>
+            <td class="othertable">   ttt and <code>"</code>sss<code>"^^</code>ddd appears in ttt <br/>
                 for ddd in D</td>
-            <td class="othertable">xxx aaa _:nnn <code>.</code><br/>
+            <td class="othertable">ttt [<code>"</code>sss<code>"^^</code>/_:nnn] <br/>
       _:nnn <code>rdf:type</code> ddd <code>.</code></td>
           </tr>
         </tbody>
@@ -1490,6 +1494,11 @@
             <td class="othertable">zzz <code>rdf:type</code> xxx <code>.</code></td>
           </tr>
           <tr >
+            <td class="othertable"><dfn>rdfs4</dfn></td>
+            <td class="othertable">ttt and xxx appears in ttt</td> 
+            <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code>
+          </tr>
+          <tr >
             <td class="othertable"><dfn>rdfs5</dfn></td>
             <td class="othertable"> xxx <code>rdfs:subPropertyOf</code> yyy <code>.</code><br />
                 yyy <code>rdfs:subPropertyOf</code> zzz <code>.</code></td>
@@ -1538,33 +1547,15 @@
             <td class="othertable">xxx <code>rdf:type rdfs:Datatype .</code></td>
             <td class="othertable">xxx <code>rdfs:subClassOf rdfs:Literal .</code></td>
           </tr>
-        </tbody>
-      </table>
-      
-      <p/>
-      
-      <table id="rdfs_entailment_patterns_recursive">
-        <tbody>
-          <tr>
-            <th ></th>
-            <th >If the triple <a>appears in</a> S:</th>
-            <th >then S RDFS <a>entails recognizing D</a>:</th>
-          </tr>
-          <tr >
-            <td class="othertable"><dfn>rdfs4</dfn></td>
-            <td class="othertable">xxx aaa yyy <code>.</code></td>
-            <td class="othertable">xxx <code>rdf:type rdfs:Resource .</code><br/>
-            yyy <code>rdf:type rdfs:Resource .</code></td>
-          </tr>
           <tr >
             <td class="othertable"><dfn>rdfs14</dfn></td>
-            <td class="othertable">xxx yyy &lt;&lt;(aaa bbb ccc)>> <code>.</code></td>
-            <td class="othertable">the graph S with the appearance replaced with<br/>
-            xxx yyy _:nnn <code></code><br/><br/>
+            <td class="othertable">ttt and  &lt;&lt;(aaa bbb ccc)&gt;&gt; appears in ttt</td>
+            <td class="othertable">ttt [&lt;&lt;(aaa bbb ccc)>>/_:nnn]<br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>
         </tbody>
       </table>
+
 
       <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14, the following graph &mdash;</p>
 


### PR DESCRIPTION
This pull request addresses the following issues: [Define the substitution function of appearances](https://github.com/w3c/rdf-semantics/issues/86) and [New entailment pattern rdfD1](https://github.com/w3c/rdf-semantics/issues/70)

I defined a substitution function and used that for the entailment patterns. 

I also slightly modified rdfs4 to better fit into the table. Note that we now also derive with that rule that all iris occurring in predicate position are resources.  This derivation happened in RDF 1.1 through two rules: rdfD2  and rdfs4.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/doerthe/rdf-semantics/pull/92.html" title="Last updated on Feb 24, 2025, 1:27 PM UTC (3a56325)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/92/39805f4...doerthe:3a56325.html" title="Last updated on Feb 24, 2025, 1:27 PM UTC (3a56325)">Diff</a>