### PR TITLE
Do not normalize language tags in D-interpretations

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -882,11 +882,11 @@
       <tbody>
         <tr><td class="semantictable">If <code>rdf:langString</code> is in D,
           then for every language-tagged string E with lexical form sss and language tag ttt,
-          IL(E)= &lt; sss, ttt' &gt;, where ttt' is ttt converted to lower case using US-ASCII rules</td></tr>
+          IL(E)= &lt; sss, ttt &gt;</td></tr>
         <tr><td class="semantictable">If <code>rdf:dirLangString</code> is in D,
           then for every directional language-tagged string E with lexical form sss,
             language tag ttt, and base direction bbb,
-          IL(E)= &lt; sss, ttt', bbb &gt;, where ttt' is ttt converted to lower case using US-ASCII rules</td></tr>
+          IL(E)= &lt; sss, ttt, bbb &gt;</td></tr>
         <tr><td class="semantictable">For every other IRI aaa in D,
           I(aaa) is the datatype identified by aaa, and for every literal
           "sss"^^aaa, IL("sss"^^aaa) = L2V(I(aaa))(sss)</td></tr>
@@ -2281,7 +2281,12 @@
   <h2>Substantive changes since RDF 1.1</h2>
 
   <ul>
-    <li> RDF entailment rule <a>rdfD1a</a> was added in RDF 1.2.  
+    <li>In D-interpretations, language tags are no longer converted to lowercase.
+      This is because the RDF 1.2 abstract syntax ignores the case of [[BCP47]] strings (unlike RDF 1.1).
+      In other words, `"chat"@fr` and `"chat"@FR` now have the <em>same</em> language tag in the abstract syntax,
+      and therefore it is not necessary to normalize them in the interpretation.
+    </li>
+    <li>RDF entailment rule <a>rdfD1a</a> was added in RDF 1.2.
       This rule should have been included in RDF 1.1 when the two built-in
       datatypes (<code>xsd:string</code> and <code>rdf:langString</code>)
       were added to RDF entailment.


### PR DESCRIPTION
In D-interpretation, language tags are no longer converted to lowercase. This is because the RDF 1.2 abstract syntax ignores the case of [[BCP47](http://localhost:8000/spec/#bib-bcp47)] strings (unlike RDF 1.1). In other words, "chat"@fr and "chat"@FR now have the *same* language tag in the abstract syntax, and therefore it is not necessary to normalize them in the interpretation.

Note also that this change does not require any other change in the semantics, IMO. In fact, it makes the job of the semantics slightly easier (as this PR shows), because the abstract syntax is now taking care of "merging" equivalent language strings rather than propagating an irrelevant difference.

----

I mark this PR as substantive because, technically, this is a breaking change in RDF 1.2 with implications on entailment.
In RDF 1.1, the following turtle files produce different graphs, which are neither isomorphic nor simply-equivalent (they are RDF-equivalent, though). 
```
#G1
:s :p "chat"@fr .
```
```
#G2
:s :p "chat"@FR.
```
In RDF 1.2, the two turtle files now produce the exact same graphs (and therefore, they are simply-equivalent)

Note however the following.
* This change is similar to the deprecation of "simple literals" in RDF 1.1. Two things that were once distinct (`"foo"` and `"foo"^^xsd:string`) are now indistinguishable, and that's for the best.
* Most implementations won't be affected, as they are normalizing literals internally already --which was explicitly allowed by the spec in RDF 1.1.  For that reason, this changes is even less disruptive than the deprecation of simple literals.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/96.html" title="Last updated on Feb 26, 2025, 4:40 PM UTC (fa012d8)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/96/6a13f0f...fa012d8.html" title="Last updated on Feb 26, 2025, 4:40 PM UTC (fa012d8)">Diff</a>