### PR TITLE
 Fix substitution mapping

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -249,7 +249,7 @@
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
   <p>
-    For RDF terms t, x, and y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
+    For RDF terms t, x, and y, where y is either not a triple term or x does not appear in y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
   </p>
   <ol>
     <li>If t = x, then t[x/y] = y.</li>

--- a/spec/index.html
+++ b/spec/index.html
@@ -249,7 +249,7 @@
     <p>A <dfn>ground</dfn> RDF graph is one that contains no blank nodes.</p>
 
   <p>
-    For RDF terms t, x, and y, where y is either not a triple term or x does not appear in y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
+    For RDF terms t, x, and y, where either y is not a triple term or x does not appear in y, we define the <dfn>substitution mapping</dfn> t[x/y] inductively, as follows:
   </p>
   <ol>
     <li>If t = x, then t[x/y] = y.</li>


### PR DESCRIPTION
This fixes issue [#104](https://github.com/w3c/rdf-semantics/issues/104).


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/106.html" title="Last updated on Mar 14, 2025, 4:09 PM UTC (e8bac4b)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/106/ba82d32...e8bac4b.html" title="Last updated on Mar 14, 2025, 4:09 PM UTC (e8bac4b)">Diff</a>