### PR TITLE
add Enrico as an editor and remove Timothée

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -23,7 +23,6 @@
         { name: "Peter Patel-Schneider", w3cid: "13382"},
         { name: "Dörthe Arndt", w3cid: "111308"},
         { name: "Enrico Franconi", w3cid: "35616"},
-        { name: "Timothée Haudebourg", w3cid: "138654"},
       ],
 
       formerEditors:  [

--- a/spec/index.html
+++ b/spec/index.html
@@ -22,6 +22,7 @@
       editors: [
         { name: "Peter Patel-Schneider", w3cid: "13382"},
         { name: "Dörthe Arndt", w3cid: "111308"},
+        { name: "Enrico Franconi", w3cid: "35616"},
         { name: "Timothée Haudebourg", w3cid: "138654"},
       ],
 


### PR DESCRIPTION
as discussed last week.
NB: I added Enrico at the end of the list, as a default option. I have no opinion on what the order should be.

Question to the chairs (@rdfguy @ktk) and other editors (@pfps @doerthe @franconi): should @timothee-haudebourg remain in the editor's list? It is not about blaming or pointing fingers (I totally understand that, since the WG started, one may have had to reorder one's priorities) but I see no contribution from him in this repo.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/113.html" title="Last updated on Mar 21, 2025, 9:47 AM UTC (b4a362e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/113/d132e32...b4a362e.html" title="Last updated on Mar 21, 2025, 9:47 AM UTC (b4a362e)">Diff</a>