### PR TITLE
[editorial] Move a `the` from an unnecessary location to a necessary location

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -91,7 +91,7 @@
 </head>
 <body>
 <section id='abstract'>
-  <p>  This document describes a precise semantics for the
+  <p>  This document describes a precise semantics for
     [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]
     and [[[RDF12-SCHEMA]]] [[RDF12-SCHEMA]].
     It defines a number of distinct entailment regimes and corresponding patterns of entailment.
@@ -99,7 +99,7 @@
 </section>
 
 <section id='sotd' class="updateable-rec">
-  <p>This document is part of RDF 1.2 document suite.
+  <p>This document is part of the RDF 1.2 document suite.
     This is a revision of the 2014 Semantics specification for RDF
     [[RDF11-MT]] and supersedes that document.
   </p>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-semantics/pull/121.html" title="Last updated on Mar 27, 2025, 4:10 PM UTC (f2d3b3a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/121/5c3c3ce...TallTed:f2d3b3a.html" title="Last updated on Mar 27, 2025, 4:10 PM UTC (f2d3b3a)">Diff</a>