### PR TITLE
fix typos in names in ack section and add acks for 1.2

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -2201,6 +2201,12 @@
 <section id="Acknowledgments" class="informative appendix" >
   <h2>Acknowledgments</h2>
 
+    <p>In addition to the editors, the following people have contributed to the RDF 1.2 version:
+      <span id="gh-contributors"></span>
+    </p>
+
+    <p data-include="common/participants.html"></p>
+
   <p>The basic idea of using an explicit extension mapping to allow self-application without
     violating the axiom of foundation was suggested by Christopher Menzel.
     The generalized RDF syntax used in <a href="#entailment_rules" class="sectionRef"></a>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -2216,8 +2216,8 @@
   <p>This specification draws upon the
     earlier specification [[RDF-MT]], whose editor acknowledged valuable
     inputs from  Jeremy Carroll, Dan Connolly, Jan Grant, R. V. Guha,
-    Herman ter Horst, Graham Klyne, Ora Lassilla, Brian McBride, Sergey
-    Melnick, Peter Patel-Schneider, Jos deRoo and Patrick Stickler. 
+    Herman ter Horst, Graham Klyne, Ora Lassila, Brian McBride, Sergey
+    Melnick, Peter Patel-Schneider, Jos De Roo and Patrick Stickler. 
     Brian McBride was the series editor for this earlier specification.</p>
 
 </section>


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/123.html" title="Last updated on Mar 27, 2025, 4:55 PM UTC (e5d2f77)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/123/4ad3bad...e5d2f77.html" title="Last updated on Mar 27, 2025, 4:55 PM UTC (e5d2f77)">Diff</a>