### PR TITLE
use versioned Turtle

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -233,7 +233,7 @@
       Angle brackets &lt; x, y &gt; are used to indicate an ordered pair of x and y.</p>
 
     <p>Throughout this document, <a>RDF graph</a>s and other fragments of RDF abstract syntax
-      are written using the notational conventions of the Turtle syntax [[!TURTLE]].
+      are written using the notational conventions of the Turtle syntax [[!RDF12-TURTLE]].
       The namespace prefixes <code>rdf:</code> <code>rdfs:</code> and <code>xsd:</code>
       are used as in [[!RDF12-CONCEPTS]],
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-vocabulary">RDF vocabularies</a>.


### PR DESCRIPTION
Fixes #122 

It turns out that Turtle is used to specify the axiomatic triples, so it is a normative reference.  But the 1.2 version of Turtle should be used.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/125.html" title="Last updated on Mar 27, 2025, 5:38 PM UTC (a263604)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/125/4ad3bad...a263604.html" title="Last updated on Mar 27, 2025, 5:38 PM UTC (a263604)">Diff</a>