### PR TITLE
make [x/y] use 'define' uniformly

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -264,7 +264,7 @@
     <li>Otherwise, t[x/y] = t.</li>
   </ol>
   <p>
-    For each triple (s, p, o), we set (s, p, o)[x/y] = (s[x/y], p[x/y], o[x/y]). For each graph G, we obtain G[x/y] by applying [x/y] to each triple t in G.
+    For any triple (s, p, o), we define (s, p, o)[x/y] as (s[x/y], p[x/y], o[x/y]). For any graph G, we define G[x/y] as the result of applying [x/y] to each triple t in G.
   </p>
 
 


### PR DESCRIPTION
I found it jarring to use "set" and some other verb instead of "define".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/132.html" title="Last updated on Jun 19, 2025, 4:48 PM UTC (4386260)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/132/0c066a6...4386260.html" title="Last updated on Jun 19, 2025, 4:48 PM UTC (4386260)">Diff</a>