### PR TITLE
improve wording around citations and make XML citations non-normative

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -231,7 +231,7 @@
       when we wish to refer to such an externally defined naming relationship,
       we will use the word <dfn class="no-export lint-ignore" data-local-lt="identified">identify</dfn> and its cognates.
       For example, the fact that the IRI <code>http://www.w3.org/2001/XMLSchema#decimal</code>
-      is widely used as the <a>name</a> of a datatype described in the XML Schema document [[XMLSCHEMA11-2]]
+      is widely used as the <a>name</a> of a datatype described in the XML Schema document [[?XMLSCHEMA11-2]]
       might be described by saying that the IRI <em>identifies</em> that datatype.
       If an IRI identifies something it may or may not denote it in a given interpretation,
       depending on how the semantics is specified.
@@ -245,7 +245,7 @@
     <p>Throughout this document, <a>RDF graph</a>s and other fragments of RDF abstract syntax
       are written using the notational conventions of the Turtle syntax [[!RDF12-TURTLE]].
       The namespace prefixes <code>rdf:</code> <code>rdfs:</code> and <code>xsd:</code>
-      are used as in [[!RDF12-CONCEPTS]],
+      are used as in the RDF Concepts specification [[!RDF12-CONCEPTS]],
       <a data-cite="RDF12-CONCEPTS#dfn-rdf-vocabulary">RDF vocabularies</a>.
       When the exact IRI does not matter, the prefix <code>ex:</code> is used.
       When stating general rules or conditions we use three-character variables such as
@@ -738,7 +738,7 @@
     which eliminates blank nodes by replacing them with "new" IRIs,
     which means IRIs which are coined for this purpose and are therefore guaranteed
     to not occur in any other RDF graph (at the time of creation).
-    See <a data-cite="RDF12-CONCEPTS#section-skolemization">Replacing Blank Nodes with IRIs</a> in [[!RDF12-CONCEPTS]]
+    See <a data-cite="RDF12-CONCEPTS#section-skolemization">Replacing Blank Nodes with IRIs</a> in the RDF Concepts specification [[!RDF12-CONCEPTS]]
     for a fuller discussion.</p>
 
   <p>Suppose G is a graph containing blank nodes and sk is a skolemization mapping
@@ -773,7 +773,7 @@
     and should treat any literals with that IRI as their datatype IRI as unknown <a>name</a>s.</p>
 
   <p>RDF literals and datatypes are fully described in the
-    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of [[!RDF12-CONCEPTS]].
+    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of the RDF Concepts specification [[!RDF12-CONCEPTS]].
     In summary: with two exceptions, RDF literals combine a string and an IRI <a data-lt="identify">identifying</a> a datatype.
     The exceptions are <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>, assigned the type <code>rdf:langString</code>,
     which have two syntactic components, a string and a language tag; and
@@ -808,7 +808,7 @@
     <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>, and
     <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string"><code>rdf:dirLangString</code></a>
     but when IRIs listed in the
-    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of [[!RDF12-CONCEPTS]]
+    <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of the RDF Concepts specification [[!RDF12-CONCEPTS]]
     <em>are</em> <a>recognized</a>, they MUST be interpreted as described there.
     RDF processors MAY recognize other datatype IRIs,
     but when other datatype IRIs are <a>recognized</a>,
@@ -909,7 +909,7 @@
       D-interpretation where D includes <code>rdf:langString</code> or <code>rdf:dirLangString</code>.
       The only ill-typed literals of type <a data-cite="XMLSCHEMA11-2#string"><code>xsd:string</code></a>
       are those containing a Unicode code point which does not match
-      the <a data-cite="XML11#NT-Char"><em>Char</em> production</a> in [[XML11]].
+      the <a data-cite="XML11#NT-Char"><em>Char</em> production</a> in [[[?XML11]]] [[?XML11]].
       Such strings cannot be written in an XML-compatible surface syntax.</p>
 
   </section>
@@ -1060,7 +1060,7 @@
     Three other datatypes &mdash; <a data-cite="RDF12-CONCEPTS#section-XMLLiteral"><code>rdf:XMLLiteral</code></a>,
     <a data-cite="RDF12-CONCEPTS#section-html"><code>rdf:HTML</code></a>, and
     <a data-cite="RDF12-CONCEPTS#section-json"><code>rdf:JSON</code></a> &mdash;
-    are defined in [[!RDF12-CONCEPTS]].
+    are defined in the RDF Concepts specification [[!RDF12-CONCEPTS]].
     RDF-D interpretations MAY fail to <a>recognize</a> these datatypes.</p>
 
   <section id="rdf_entail">
@@ -1661,7 +1661,7 @@
 <p> <em> Note: This section is carried over from RDF 1.1 and is included here to show how sound and complete inference rules might be constructed for the current versions of RDF and RDFS.  It is believed that at most minor changes to the entailment rules here will be needed for sound and complete RDF and RDFS entailment. </em> </p>
 
 
-  <p>(<em>This section is based on work described more fully in </em>[[HORST04]]<em>, </em>[[HORST05]]<em>,
+  <p>(<em>This section is based on work described more fully in two papers by ter Horst, </em>[[HORST04]]<em> and </em>[[HORST05]]<em>,
     which should be consulted for technical details and proofs.</em>) </p>
 
   <p>The RDF and RDFS entailment patterns listed in the above tables can be viewed
@@ -1726,8 +1726,8 @@
   <!--<p>Define a <dfn>generalized RDF triple</dfn> to be a triple &lt;x, y, z&gt; where x and z can be an IRI, a blank node or a literal, and y can be an IRI or a blank node; and extend this to the rest of RDF, so that a generalized RDF graph is a set of generalized RDF triples. -->
 
   <p>Consider <a data-cite="RDF12-CONCEPTS#section-generalized-rdf">generalized RDF triples, graphs, and datasets</a>
-    instead of RDF triples, graphs and datasets (extending the generalization used in [[HORST04]]
-    and following exactly the terms used in [[OWL2-PROFILES]]).
+    instead of RDF triples, graphs and datasets (extending the generalization used by Horst [[HORST04]]
+    and following exactly the terms used in OWL Profiles [[OWL2-PROFILES]]).
     The semantics described in this document applies to the generalization without change,
     so that the notions of interpretation, satisfiability and entailment can be used freely.
     Then we can replace the first RDF entailment pattern with the simpler and more direct</p>
@@ -2232,13 +2232,13 @@
 <section id="privacy" class="informative appendix">
   <h2>Privacy Considerations</h2>
   <p>
-    See <a data-cite="RDF12-CONCEPTS#privacy">Privacy Considerations</a> in [[RDF12-CONCEPTS]].
+    See <a data-cite="RDF12-CONCEPTS#privacy">Privacy Considerations</a> in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
   </p>
 </section>
 <section id="security" class="informative appendix">
   <h2>Security Considerations</h2>
   <p>
-    See <a data-cite="RDF12-CONCEPTS#security">Security Considerations</a> in [[RDF12-CONCEPTS]].
+    See <a data-cite="RDF12-CONCEPTS#security">Security Considerations</a> in [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]].
   </p>
 </section>
 
@@ -2264,7 +2264,7 @@
     Eric Prud'hommeaux, Andy Seaborne, David Wood and Antoine Zimmermann. </p>
 
   <p>This specification draws upon the
-    earlier specification [[RDF-MT]], whose editor acknowledged valuable
+    earlier specification for RDF semantics [[RDF-MT]], whose editor acknowledged valuable
     inputs from  Jeremy Carroll, Dan Connolly, Jan Grant, R. V. Guha,
     Herman ter Horst, Graham Klyne, Ora Lassila, Brian McBride, Sergey
     Melnick, Peter Patel-Schneider, Jos De Roo and Patrick Stickler. 
@@ -2296,7 +2296,7 @@
       and introduced the special type
       <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>
       for language-tagged strings.
-      The full semantics for typed literals is given in section [[[#datatypes]]].
+      The full semantics for typed literals is given in Section [[[#datatypes]]].
   </li>
 
   <li>In the RDF 1.0 specification
@@ -2354,7 +2354,7 @@
     <li>
       In RDF 1.1, <code>rdf:PlainLiteral</code> was described as an optional datatype
       that, "[if] [recognized](https://www.w3.org/TR/rdf11-mt/#dfn-recognize), ...
-      MUST be interpreted to [denote] the datatype defined in [[RDF-PLAIN-LITERAL]]."
+      MUST be interpreted to [denote] the datatype defined in [[[RDF-PLAIN-LITERAL]]] [[RDF-PLAIN-LITERAL]]."
       <code>rdf:PlainLiteral</code> is not used elsewhere in the RDF documents,
       so the requirement to give it this particular semantics has been removed.
       It is recommended that <code>rdf:PlainLiteral</code> not be used in RDF.


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/138.html" title="Last updated on Jul 3, 2025, 6:11 PM UTC (e30d9da)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/138/48cc696...e30d9da.html" title="Last updated on Jul 3, 2025, 6:11 PM UTC (e30d9da)">Diff</a>