### PR TITLE
clarifies wording defining "RDF Literals"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -779,7 +779,7 @@
     which are assigned the type <code>rdf:langString</code>, and
     <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>,
     which are assigned the type <code>rdf:dirLangString</code>.
-    <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>
+    <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">Language-tagged strings</a>
     have two syntactic components, these being a string and a language tag;
     <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>
     have three syntactic components, these being a string, a language tag, and a base direction.

--- a/spec/index.html
+++ b/spec/index.html
@@ -775,11 +775,14 @@
   <p>RDF literals and datatypes are fully described in the
     <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of [[!RDF12-CONCEPTS]].
     In summary: with two exceptions, RDF literals combine a string and an IRI <a data-lt="identify">identifying</a> a datatype.
-    The exceptions are <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>, assigned the type <code>rdf:langString</code>,
-    which have two syntactic components, a string and a language tag; and
-    <a data-cite="RDF12-CONCEPTS#dfn-dir-lang-string">directional language-tagged strings</a>,
-    assigned the type <code>rdf:dirLangString</code>,
-    which have three syntactic components, a string, a language tag, and a base direction.
+    The exceptions are <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
+    which are assigned the type <code>rdf:langString</code>, and
+    <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>,
+    which are assigned the type <code>rdf:dirLangString</code>.
+    <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>
+    have two syntactic components, these being a string and a language tag;
+    <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>
+    have three syntactic components, these being a string, a language tag, and a base direction.
     A datatype is understood to define a mapping, called the
     <span id="dfn-lexical-to-value-mapping"></span>
     <dfn data-cite="RDF12-CONCEPTS#dfn-lexical-to-value-mapping">lexical-to-value mapping</dfn>,

--- a/spec/index.html
+++ b/spec/index.html
@@ -776,13 +776,13 @@
     <a data-cite="RDF12-CONCEPTS#section-Datatypes">Datatypes</a> section of [[!RDF12-CONCEPTS]].
     In summary: with two exceptions, RDF literals combine a string and an IRI <a data-lt="identify">identifying</a> a datatype.
     The exceptions are <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">language-tagged strings</a>,
-    which are assigned the type <code>rdf:langString</code>, and
+    which have the type <code>rdf:langString</code>, and
     <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>,
-    which are assigned the type <code>rdf:dirLangString</code>.
+    which have the type <code>rdf:dirLangString</code>.
     <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string">Language-tagged strings</a>
-    have two syntactic components, these being a string and a language tag;
+    have two syntactic components: a string, and a language tag;
     <a data-cite="RDF12-CONCEPTS#dfn-directional-language-tagged string">directional language-tagged strings</a>
-    have three syntactic components, these being a string, a language tag, and a base direction.
+    have three syntactic components: a string, a language tag, and a base direction.
     A datatype is understood to define a mapping, called the
     <span id="dfn-lexical-to-value-mapping"></span>
     <dfn data-cite="RDF12-CONCEPTS#dfn-lexical-to-value-mapping">lexical-to-value mapping</dfn>,


### PR DESCRIPTION
fixes #83


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-semantics/pull/143.html" title="Last updated on Jul 24, 2025, 4:33 PM UTC (c626825)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/143/ca90378...TallTed:c626825.html" title="Last updated on Jul 24, 2025, 4:33 PM UTC (c626825)">Diff</a>