### PR TITLE
No connection between propositions and facts in model-theoretic semantics

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -710,7 +710,7 @@
     <p class="fact"> If E contains an IRI which does not occur anywhere in S,
       then S does not simply entail E.</p>
       
-    <p>The following semantic properties relate triple terms and triples asserted in a graph, and they introduce a general definition of satisfiability.</p>
+    <p>The following semantic properties relate triple terms, triples asserted in a graph and reified triples, and they introduce a general definition of satisfiability.</p>
     
     <p>We define the <dfn>set of propositions</dfn> in an interpretation as follows:</p>
 
@@ -720,20 +720,20 @@
 
 	<p class="fact"> The set F of facts in an interpretation I is F(I) = {&nbsp;RE(x, y, z)&#65372;&lt;x, z&gt; is in IEXT(y)&nbsp;}. The set of facts is the set of propositions which are true in the interpretation. </p>
 
-        <p>
-		Note however that reifying a proposition never entails a fact, and neither does a fact entail a reified proposition.
-		From that follows that an assertion on a reification can never be an assertion on a fact of the same form (i.e. the same triple).
-		In the strict model-theoretic interpretation of semantics the connection between a (reified) proposition and a fact of the same form 
-		can only be understood as being merely coincidental, even if they occur in the same graph. 
-		A looser interpretation of that connection as one of <a href="https://w3c.github.io/rdf-semantics/spec/#dfn-identify">identification</a>, 
-		not <a href="https://www.w3.org/TR/rdf12-concepts/#dfn-denote">denotation</a>, as applied in RDF 1.2 Concepts and RDF 1.2 Primer,
-		may try to establish an operational semantics of such a connection between (reified) proposition and fact as convention and best practice.
-	</p>
+	<p>We define the <dfn>set of reifications</dfn> in an interpretation as follows:</p>
+
+	<p class="fact"> The set R of reifications in an interpretation I is R(I) = {&nbsp;RE(x, y, z)&#65372;
+		x is in IR,
+		y is rdf:reifies,
+		z is a triple term and 
+		&lt;x, z&gt; is in IEXT(y)&nbsp;}. 
+		The set of reifications is the multi-set of propositions which are reified in an interpretation. </p>
+
 	  
 	<p>Given a blank node mapping, we define the <dfn>set of facts asserted by a graph</dfn> in an interpretation as follows:</p>
 
 	<p class="fact">Given a blank node mapping A, the set of all facts asserted by a graph G in an interpretation I is FEXT(G, I, A) = {&nbsp;RE(&nbsp;[I+A](s), I(p), [I+A](o)&nbsp;)&#65372;`s p o.` is in G&nbsp;}. We then observe that given a blank node mapping, the asserted facts of a graph with respect to an interpretation may not necessarily be among the facts of the interpretation.</p>
-	
+  
 	<p>We introduce a <dfn>general definition of satisfiability</dfn> of a graph in an interpretation as follows:</p>
 
 	<p class="fact">An interpretation (simply) satisfies a graph if and only if there exists a blank node mapping such that the facts asserted by the graph in the interpretation are among the facts of the interpretation.</p>
@@ -1969,8 +1969,52 @@
     processes to check formal RDF entailment. For example, implementations may decide
     to use special procedural techniques to implement the RDF collection vocabulary.</p>
 
+
+  <section id="TTerms">
+    <h3>RDF 1.2 reification - triple terms and reifiers</h3>
+    <p>
+	To repeat nomenclatura:
+	<ul>
+		<li>an `rdfs:Proposition` subsumes multiple kinds of triples: 
+	    		abstract triples, asserted triples and reified triples
+		</li>
+		<li>an abstract triple is encoded as a triple term</li>
+		<li>an asserted triple is also called a fact, 
+	    		and also known as an RDF statement 
+	    		or simply as a triple in the graph</li>
+		<li>a reified triple is represented by a reifier and defined by 
+	    		a fact with `rdf:reifies` as the predicate, 
+	    		the reified triple term as the object
+	    		and a reifier, denoting the reification, as the subject.</li>
+	</ul>.
+
+	Reifying an abstract proposition, encoded as a triple term, 
+	    never entails that triple as a fact.
+	Neither does a fact entail a reification of that triple.
+	
+	From that follows that in a strict interpretation of the model-theoretic semantics of RDF 1.2
+	    an assertion on a reified triple (denoted by a reifier) 
+	    can never be an assertion on a fact asserting that same triple.
+	The connection between a reification and an assertion of the same triple,
+	    even if they occur in the same graph,
+	    can only be understood as being merely coincidental.
+	  
+	A looser interpretation of that connection 
+	    as one of <a href="https://w3c.github.io/rdf-semantics/spec/#dfn-identify">identification</a>, 
+	    not <a href="https://www.w3.org/TR/rdf12-concepts/#dfn-denote">denotation</a>, 
+	    as applied in RDF 1.2 Concepts, RDF 1.2 Primer and the RDF 1.2 note on triple terms (tbd),
+	    establishes an operational semantics of such a connection between reification and fact 
+	    as convention and best practice.
+	The semantics of RDF 1.2's triple term-based reification mechanism thus diverges
+	    from RDF 1.0/1.1 reification which strictly upholds the model-theoretic interpretation
+	    that reified and asserted triple have no connection beyond mere coincidence.
+	This design was chosen to facilitate assertions on asserted triples, a.k.a. "statements about statements",
+	    while keeping the model-theoretic semantics of RDF 1.2 simple 
+	    and upholding a safe distance from modal logic complications.
+    </p>
+	
   <section id="Reif">
-    <h3>Reification</h3>
+    <h3>RDF 1.0/1.1 reification - statement quad reification </h3>
 
     <div class="c1">
       <table>


### PR DESCRIPTION
Add clarification that annotations on propositions can't annotate facts according to the model-theoretic semantics, but that an operational semantics may nudge users towards assuming such a connection.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/rat10/rdf-semantics/pull/144.html" title="Last updated on Jul 24, 2025, 10:45 AM UTC (8505cea)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/144/ca90378...rat10:8505cea.html" title="Last updated on Jul 24, 2025, 10:45 AM UTC (8505cea)">Diff</a>