### PR TITLE
remove dangling reference to deleted Appendix D and clarify normative meaning statement

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1044,8 +1044,8 @@
     </tr>
   </table>
 
-  <p>RDF imposes no particular normative meanings on the rest of the RDF vocabulary.
-    <a href="#whatnot">Appendix D</a> describes the intended uses of some of this vocabulary.</p>
+  <p>RDF intrepretations impose no particular normative semantics on the rest of the RDF vocabulary.
+</p>
 
   <p>The datatype IRIs 
     <a data-cite="RDF12-CONCEPTS#dfn-language-tagged-string"><code>rdf:langString</code></a>,


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/147.html" title="Last updated on Jul 31, 2025, 10:27 AM UTC (d172fbe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/147/475dde5...d172fbe.html" title="Last updated on Jul 31, 2025, 10:27 AM UTC (d172fbe)">Diff</a>