### PR TITLE
remove use of abstract syntax in text

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -242,7 +242,7 @@
       The statement "A = B" means that there is one entity which both expressions "A" and "B" denote. 
       Angle brackets &lt; x, y &gt; are used to indicate an ordered pair of x and y.</p>
 
-    <p>Throughout this document, <a>RDF graph</a>s and their components
+    <p>Throughout this document, <a>RDF graphs</a> and their components
       are written using the notational conventions of the Turtle syntax [[!RDF12-TURTLE]].
       The namespace prefixes <code>rdf:</code> <code>rdfs:</code> and <code>xsd:</code>
       are used as in the RDF Concepts specification [[!RDF12-CONCEPTS]],


### PR DESCRIPTION
Change sole use of "abstract syntax" to components of RDF graphs.  This not only removes a problematic phrase but better describes what is going on.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/152.html" title="Last updated on Aug 23, 2025, 1:07 PM UTC (5d053f3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/152/cfab1f2...5d053f3.html" title="Last updated on Aug 23, 2025, 1:07 PM UTC (5d053f3)">Diff</a>