### PR TITLE
fixing grammar errors (Issue #158)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -780,7 +780,7 @@
     sk(G) <a>simply entails</a> H if and only if G <a>simply entails</a> H.</p>
 
   <p>The second property means that a graph is not logically <a>equivalent</a> to its skolemization.
-    Nevertheless, they have in a strong sense almost interchangeable
+    Nevertheless, they are in a strong sense almost interchangeable in
     <a data-cite="RDF12-SEMANTICS#simple">RDF simple interpretations</a>,
     as shown by the next two properties. The third property means that even
     when conclusions which do contain the new vocabulary are drawn with


### PR DESCRIPTION
GitHub's interface revision games mean I can only preview side-by-side (anyone know how to switch preview presentation?), which doesn't properly highlight character-level changes. Please use your own preferred diff tool to see the changes.

This closes #158.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/TallTed/rdf-semantics/pull/159.html" title="Last updated on Sep 26, 2025, 7:06 PM UTC (bb60a62)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/159/ae712ac...TallTed:bb60a62.html" title="Last updated on Sep 26, 2025, 7:06 PM UTC (bb60a62)">Diff</a>