### PR TITLE
Fixes correctness of Appendix A (from issue #139)

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1853,7 +1853,8 @@
     <li>For each container membership property IRI which occurs in E, add the RDF (and RDFS) axiomatic triples which contain that IRI.</li>
     <li>If no triples were added in step 2, add the RDF (and RDFS) axiomatic triples which contain <code>rdf:_1</code>.</li>
     <li>Apply the rule GrdfD1 (and rdfs1 and rdfs4) but using E instead of S in the antecedent.</li>
-    <li>Apply the rules <a>GrdfD1</a>, <a>rdfD1a</a>, and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a> and <a>Grdfs14</a>),
+    <li> Apply rule <a>Grdfs14</a>. </li>
+    <li>Apply the rules <a>GrdfD1</a>, <a>rdfD1a</a>, and <a>rdfD2</a> (and the rules <a>rdfs1</a> through <a>rdfs13</a>),
       with D={<code>rdf:langString</code>, <code>rdf:dirLangString</code>, <code>xsd:string</code>},
       to the set in all possible ways, to exhaustion.</li>
   </ol>


### PR DESCRIPTION
Closes #139


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/franconi/rdf-semantics-fork-enrico/pull/160.html" title="Last updated on Nov 6, 2025, 2:28 AM UTC (4c4ed37)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/160/07319e5...franconi:4c4ed37.html" title="Last updated on Nov 6, 2025, 2:28 AM UTC (4c4ed37)">Diff</a>