### PR TITLE
added non-well foundedness note

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1513,6 +1513,40 @@
 
     <p> aaa <code>rdf:type rdfs:Resource .</code></p>
 
+	<p class="technote"> 
+		The RDFS semantic condition on the triple term mapping IT induces 
+		unwanted <i>non-well founded models</i> for propositions.
+		
+		For example, the asserted triple 
+		
+		<p></p>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</p>
+	  
+		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
+		and x is an instance of the denotation of rdfs:Proposition. 
+	  
+		In this interpretation, there is a proposition about a relation involving the proposition itself 
+		-- for example it could be intended as the proposition "the barber denies this very proposition",
+		leading to a self referential paradoxe. 
+	  
+	  However, it should be noted that: 
+	  
+		<ol>
+			<li> interpretations like the above do not induce any formal paradox, 
+				since in RDF the notion of proposition is very weak, and most importantly, </li>
+			
+			<li> it can be shown that if we tweak the semantic condition on IT 
+				by requiring the mapping to be well-founded -- in order to forbid 
+				"self-referential" interpretations like the above --
+				the simple, RDF, and RDFS entailments do not change.</li>
+		</ol>
+	  
+		Therefore, we do not impose a well foundedness condition on the definition of IT, 
+	    since this would have no practical consequence for simple, RDF, and RDFS entailments.
+		However, a well foundedness condition may be necessary in extensions of RDF 
+	    in which the indifference of entailment with respect to non-well founded interpretations 
+	    does not hold anymore, such as in the case of RDF extended with owl:sameAs.
+	</p> 
+
     <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
 
     <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">

--- a/spec/index.html
+++ b/spec/index.html
@@ -1522,7 +1522,7 @@
 		and x is an instance of the denotation of rdfs:Proposition. 	  
 		In this interpretation, there is a proposition about a relation involving the proposition itself 
 		-- for example it could be intended as the proposition "the barber denies this very proposition",
-		leading to a self referential paradoxe. 	  
+		leading to a self referential paradox. 	  
 	  However, it should be noted that: 	  
 		(a) interpretations like the above do not induce any formal paradox, 
 				since in RDF the notion of proposition is very weak, and most importantly, 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1518,8 +1518,8 @@
 		unwanted <i>non-well founded models</i> for propositions.		
 		For example, the asserted triple 		
 		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  
-		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
-		and x is an instance of the denotation of rdfs:Proposition. 	  
+		is satisfied in the interpretation where IT maps the triple term &lt;x,y,z&gt; to its subject x, 
+		and x is (necessarily) an instance of the denotation of rdfs:Proposition. 	  
 		In this interpretation, there is a proposition about a relation involving the proposition itself 
 		-- for example it could be intended as the proposition "the barber denies this very proposition",
 		leading to a self referential paradox. 	  

--- a/spec/index.html
+++ b/spec/index.html
@@ -1980,7 +1980,7 @@
     simple entailment and satisfiability</a> — and therefore I(:c) is
     an instance of the denotation of <code>rdfs:Proposition</code>.</p>
     <p>In this interpretation, there is a proposition about a relation 
-    involving the proposition itself — for example it could be intended 
+    involving the proposition itself — for example, it could be intended 
     as the proposition &ldquo;the barber denies this very proposition&rdquo; — 
     leading to a self-referential paradox.</p>
     <p>However, it should be noted that:</p>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1519,27 +1519,30 @@
 	  <p>
         The RDFS semantic condition on the triple term mapping IT induces 
 		potentially unwanted <i>non-well founded models</i> for propositions.		
-		For example, the asserted triple 		
-		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  
-		is satisfied in the interpretation where IT maps the denotation of the triple term &lt;x,y,z&gt; 
-		to the denotation of its subject x, 
-		and x is (necessarily) an instance of the denotation of rdfs:Proposition. 	  
-		In this interpretation, there is a proposition about a relation involving the proposition itself 
-		-- for example it could be intended as the proposition "the barber denies this very proposition",
-		leading to a self referential paradox. 	  
-	  However, it should be noted that: 	  
-		(a) interpretations like the above do not induce any formal paradox, 
-				since in RDF the notion of proposition is very weak, and most importantly, 
-		(b) it can be shown that if we tweak the semantic condition on IT 
-				by requiring the mapping to be well-founded -- in order to forbid 
-				"self-referential" interpretations like the above --
-				the simple, RDF, and RDFS entailments do not change.
-		Therefore, we do not impose a well foundedness condition on the definition of IT, 
-	    since this would have no practical consequence for simple, RDF, and RDFS entailments.
-		However, a well foundedness condition may be necessary in extensions of RDF 
-	    in which the indifference of entailment with respect to non-well founded interpretations 
-	    does not hold anymore, such as in the case of RDF extended with owl:sameAs.
-	</p> 
+        <p>For example, the asserted triple <br>
+          &lt;&lt;( :a :b :c )&gt;&gt; :p :o . <br>
+          is satisfied in the interpretation where IT maps the denotation of the triple term &lt;x,y,z&gt;
+          to the denotation of its subject, x,
+          and x is (necessarily) an instance of the denotation of <code>rdfs:Proposition</code>.</p>
+        <p>In this interpretation, there is a proposition about a relation involving the proposition itself
+          &mdash; for example it could be intended as the proposition "the barber denies this very proposition" &mdash;
+          leading to a self-referential paradox.</p>
+        <p>However, it should be noted that:</p>
+          <ol type="a">
+            <li>Interpretations like the above do not induce any formal paradox,
+              since the notion of "proposition" in RDF is very weak.</li>
+            <li>Most importantly, it can be shown that if we tweak the semantic condition on IT,
+            by requiring the mapping to be well-founded &mdash; in order to forbid
+            "self-referential" interpretations like the above &mdash;
+            neither the simple, RDF, nor RDFS entailments change.</li>
+          </ol>
+        <p>Therefore, we do not impose a well-foundedness condition on the definition of IT,
+          since this would have no practical consequence for simple, RDF, or RDFS entailments.
+          However, such a well-foundedness condition may be necessary in extensions of RDF
+          in which the indifference of entailment with respect to non-well-founded interpretations
+          does not hold anymore, such as in the case of RDF extended with <code>owl:sameAs</code>.
+        </p>
+    <div class="technote">
 
     <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
       <h4>Patterns of RDFS entailment</h4>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1524,14 +1524,12 @@
 		-- for example it could be intended as the proposition "the barber denies this very proposition",
 		leading to a self referential paradoxe. 	  
 	  However, it should be noted that: 	  
-		<ol>
-			<li> interpretations like the above do not induce any formal paradox, 
-				since in RDF the notion of proposition is very weak, and most importantly, </li>			
-			<li> it can be shown that if we tweak the semantic condition on IT 
+		(a) interpretations like the above do not induce any formal paradox, 
+				since in RDF the notion of proposition is very weak, and most importantly, 
+		(b) it can be shown that if we tweak the semantic condition on IT 
 				by requiring the mapping to be well-founded -- in order to forbid 
 				"self-referential" interpretations like the above --
-				the simple, RDF, and RDFS entailments do not change.</li>
-		</ol>	  
+				the simple, RDF, and RDFS entailments do not change.
 		Therefore, we do not impose a well foundedness condition on the definition of IT, 
 	    since this would have no practical consequence for simple, RDF, and RDFS entailments.
 		However, a well foundedness condition may be necessary in extensions of RDF 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1515,35 +1515,6 @@
 
     <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
 
-	<div class="technote">
-	  <p>
-        The RDFS semantic condition on the triple term mapping IT induces 
-		potentially unwanted <i>non-well founded models</i> for propositions.		
-        <p>For example, the asserted triple <br>
-          &lt;&lt;( :a :b :c )&gt;&gt; :p :o . <br>
-          is satisfied in the interpretation where IT maps the denotation of the triple term, &lt;x,y,z&gt;,
-          to the denotation of its subject, x,
-          and x is (necessarily) an instance of the denotation of <code>rdfs:Proposition</code>.</p>
-        <p>In this interpretation, there is a proposition about a relation involving the proposition itself
-          &mdash; for example it could be intended as the proposition "the barber denies this very proposition" &mdash;
-          leading to a self-referential paradox.</p>
-        <p>However, it should be noted that:</p>
-          <ol type="a">
-            <li>Interpretations like the above do not induce any formal paradox,
-              since the notion of "proposition" in RDF is very weak.</li>
-            <li>Most importantly, it can be shown that if we tweak the semantic condition on IT,
-            by requiring the mapping to be well-founded &mdash; in order to forbid
-            "self-referential" interpretations like the above &mdash;
-            neither the simple, RDF, nor RDFS entailments change.</li>
-          </ol>
-        <p>Therefore, we do not impose a well-foundedness condition on the definition of IT,
-          since this would have no practical consequence for simple, RDF, or RDFS entailments.
-          However, such a well-foundedness condition may be necessary in extensions of RDF
-          in which the indifference of entailment with respect to non-well-founded interpretations
-          does not hold anymore, such as in the case of RDF extended with <code>owl:sameAs</code>.
-        </p>
-	</div>
-
     <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
       <h4>Patterns of RDFS entailment</h4>
 
@@ -1992,6 +1963,41 @@
     So if sk(G) entails H then G entails ks(H)=H; and if G entails H then sk(G) entails G entails H, so sk(G) entails H. QED.</p>
 
 </section>
+
+	
+<section id="adequacy" class="informative appendix">
+  <h2>Semantic Adequacy Considerations</h2>
+    <p>The semantic condition on the triple term mapping IT induces 
+    potentially unwanted <em>non-well founded models</em> for propositions.</p>
+    <p>For example, the following asserted triple<br>
+    :s :p &lt;&lt;( :a :b :c )&gt;&gt; .<br>
+    is satisfied, among many interpretations, in an interpretation I in which IT 
+    maps the denotation of the triple term &lt;&lt;( :a :b :c )&gt;&gt; 
+    to the denotation of its object — i.e., IT( I(:a), I(:b), I(:c) ) = I(:c).
+    Observe that I(:c) is a <i>proposition</i> in the interpretation I, 
+    namely it is an element of the set IPR(I) — as defined in the section on the <a data-cite="RDF12-SEMANTICS#simple_entailment_properties">properties of 
+    simple entailment and satisfiability</a> —
+    and therefore I(:c) is an instance of the denotation of <code>rdfs:Proposition</code>.</p>
+    <p>In this interpretation, there is a proposition about a relation 
+    involving the proposition itself — for example it could be intended 
+    as the proposition &ldquo;the barber denies this very proposition&rdquo; — 
+    leading to a self-referential paradox.</p>
+    <p>However, it should be noted that:</p>
+    <ol type="a">
+      <li>Interpretations like the above do not induce any formal paradox, 
+      since the notion of <i>proposition</i> in RDF is very weak.</li>
+      <li>Most importantly, it can be shown that even if we strengthen the 
+      semantic condition on IT  in order to forbid paradoxical self-referential 
+      interpretations like the above — by requiring the mapping IT to be well-founded — 
+      neither the simple, RDF, nor RDFS entailments change.</li>
+    </ol>
+    <p>Therefore, we do not enforce a well-foundedness condition on the definition of IT, 
+    since this would have no practical consequence for simple, RDF, or RDFS entailments. 
+    However, such a well-foundedness condition may be necessary in extensions of RDF 
+    in which the indifference of entailment with respect to non-well-founded interpretations 
+    does not hold anymore, such as in the case of RDF extended with <code>owl:sameAs</code>.</p>
+</section>
+
 
 <section id="privacy" class="informative appendix">
   <h2>Privacy Considerations</h2>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1519,7 +1519,7 @@
 		
 		For example, the asserted triple 
 		
-		<br>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</br>
+		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.
 	  
 		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
 		and x is an instance of the denotation of rdfs:Proposition. 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1987,10 +1987,10 @@
     <ol type="a">
       <li>Interpretations like the above do not induce any formal paradox, 
       since the notion of <i>proposition</i> in RDF is very weak.</li>
-      <li>Most importantly, it can be shown that even if we strengthen the 
-      semantic condition on IT  in order to forbid paradoxical self-referential 
-      interpretations like the above — by requiring the mapping IT to be well-founded — 
-      neither the simple, RDF, nor RDFS entailments change.</li>
+      <li>Most importantly, it can be shown that even if we strengthen the
+      semantic condition on IT in order to forbid paradoxical self-referential
+      interpretations like the above — e.g., by requiring the mapping IT to be
+      well-founded — neither the simple, RDF, nor RDFS entailments change.</li>
     </ol>
     <p>Therefore, we do not enforce a well-foundedness condition on the definition of IT, 
     since this would have no practical consequence for simple, RDF, or RDFS entailments. 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1542,7 +1542,7 @@
           in which the indifference of entailment with respect to non-well-founded interpretations
           does not hold anymore, such as in the case of RDF extended with <code>owl:sameAs</code>.
         </p>
-    <div class="technote">
+	</div>
 
     <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
       <h4>Patterns of RDFS entailment</h4>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1519,7 +1519,7 @@
 		
 		For example, the asserted triple 
 		
-		<p></p>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</p>
+		<br></p>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</br>
 	  
 		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
 		and x is an instance of the denotation of rdfs:Proposition. 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1521,7 +1521,7 @@
 		potentially unwanted <i>non-well founded models</i> for propositions.		
         <p>For example, the asserted triple <br>
           &lt;&lt;( :a :b :c )&gt;&gt; :p :o . <br>
-          is satisfied in the interpretation where IT maps the denotation of the triple term, &lt;x,y,z&gt;
+          is satisfied in the interpretation where IT maps the denotation of the triple term, &lt;x,y,z&gt;,
           to the denotation of its subject, x,
           and x is (necessarily) an instance of the denotation of <code>rdfs:Proposition</code>.</p>
         <p>In this interpretation, there is a proposition about a relation involving the proposition itself

--- a/spec/index.html
+++ b/spec/index.html
@@ -1975,7 +1975,8 @@
     maps the denotation of the triple term &lt;&lt;( :a :b :c )&gt;&gt; 
     to the denotation of its object — i.e., IT( I(:a), I(:b), I(:c) ) = I(:c).
     Observe that I(:c) is a <i>proposition</i> in the interpretation I, 
-    namely it is an element of the set IPR(I) — as defined in the section on the <a data-cite="RDF12-SEMANTICS#simple_entailment_properties">properties of 
+    namely it is an element of the set IPR(I) — as defined in the section on the
+    <a data-cite="RDF12-SEMANTICS#simple_entailment_properties">properties of
     simple entailment and satisfiability</a> —
     and therefore I(:c) is an instance of the denotation of <code>rdfs:Proposition</code>.</p>
     <p>In this interpretation, there is a proposition about a relation 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1521,7 +1521,7 @@
 		potentially unwanted <i>non-well founded models</i> for propositions.		
         <p>For example, the asserted triple <br>
           &lt;&lt;( :a :b :c )&gt;&gt; :p :o . <br>
-          is satisfied in the interpretation where IT maps the denotation of the triple term &lt;x,y,z&gt;
+          is satisfied in the interpretation where IT maps the denotation of the triple term, &lt;x,y,z&gt;
           to the denotation of its subject, x,
           and x is (necessarily) an instance of the denotation of <code>rdfs:Proposition</code>.</p>
         <p>In this interpretation, there is a proposition about a relation involving the proposition itself

--- a/spec/index.html
+++ b/spec/index.html
@@ -1519,7 +1519,7 @@
 		
 		For example, the asserted triple 
 		
-		<br></p>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</br>
+		<br>&lt;&lt;( :a :b :c )&gt;&gt; :p :o.</br>
 	  
 		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
 		and x is an instance of the denotation of rdfs:Proposition. 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1513,6 +1513,8 @@
 
     <p> aaa <code>rdf:type rdfs:Resource .</code></p>
 
+    <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
+
 	<p class="technote"> 
 		The RDFS semantic condition on the triple term mapping IT induces 
 		unwanted <i>non-well founded models</i> for propositions.		
@@ -1537,8 +1539,6 @@
 	    in which the indifference of entailment with respect to non-well founded interpretations 
 	    does not hold anymore, such as in the case of RDF extended with owl:sameAs.
 	</p> 
-
-    <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
 
     <section id="rdfs_patterns" class="informative" data-dfn-for="RDFS entailment patterns">
       <h4>Patterns of RDFS entailment</h4>

--- a/spec/index.html
+++ b/spec/index.html
@@ -1518,7 +1518,8 @@
 		unwanted <i>non-well founded models</i> for propositions.		
 		For example, the asserted triple 		
 		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  
-		is satisfied in the interpretation where IT maps the triple term &lt;x,y,z&gt; to its subject x, 
+		is satisfied in the interpretation where IT maps the denotation of the triple term &lt;x,y,z&gt; 
+		to the denotation of its subject x, 
 		and x is (necessarily) an instance of the denotation of rdfs:Proposition. 	  
 		In this interpretation, there is a proposition about a relation involving the proposition itself 
 		-- for example it could be intended as the proposition "the barber denies this very proposition",

--- a/spec/index.html
+++ b/spec/index.html
@@ -1515,8 +1515,9 @@
 
     <p>where aaa is an IRI, are true in all RDFS interpretations.</p>
 
-	<p class="technote"> 
-		The RDFS semantic condition on the triple term mapping IT induces 
+	<div class="technote">
+	  <p>
+        The RDFS semantic condition on the triple term mapping IT induces 
 		potentially unwanted <i>non-well founded models</i> for propositions.		
 		For example, the asserted triple 		
 		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  

--- a/spec/index.html
+++ b/spec/index.html
@@ -1977,8 +1977,8 @@
     Observe that I(:c) is a <i>proposition</i> in the interpretation I, 
     namely it is an element of the set IPR(I) — as defined in the section on the
     <a data-cite="RDF12-SEMANTICS#simple_entailment_properties">properties of
-    simple entailment and satisfiability</a> —
-    and therefore I(:c) is an instance of the denotation of <code>rdfs:Proposition</code>.</p>
+    simple entailment and satisfiability</a> — and therefore I(:c) is
+    an instance of the denotation of <code>rdfs:Proposition</code>.</p>
     <p>In this interpretation, there is a proposition about a relation 
     involving the proposition itself — for example it could be intended 
     as the proposition &ldquo;the barber denies this very proposition&rdquo; — 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1515,31 +1515,23 @@
 
 	<p class="technote"> 
 		The RDFS semantic condition on the triple term mapping IT induces 
-		unwanted <i>non-well founded models</i> for propositions.
-		
-		For example, the asserted triple 
-		
-		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.
-	  
+		unwanted <i>non-well founded models</i> for propositions.		
+		For example, the asserted triple 		
+		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  
 		is satisfied in the interpretation where IT maps &lt;x,y,z&gt; to x, 
-		and x is an instance of the denotation of rdfs:Proposition. 
-	  
+		and x is an instance of the denotation of rdfs:Proposition. 	  
 		In this interpretation, there is a proposition about a relation involving the proposition itself 
 		-- for example it could be intended as the proposition "the barber denies this very proposition",
-		leading to a self referential paradoxe. 
-	  
-	  However, it should be noted that: 
-	  
+		leading to a self referential paradoxe. 	  
+	  However, it should be noted that: 	  
 		<ol>
 			<li> interpretations like the above do not induce any formal paradox, 
-				since in RDF the notion of proposition is very weak, and most importantly, </li>
-			
+				since in RDF the notion of proposition is very weak, and most importantly, </li>			
 			<li> it can be shown that if we tweak the semantic condition on IT 
 				by requiring the mapping to be well-founded -- in order to forbid 
 				"self-referential" interpretations like the above --
 				the simple, RDF, and RDFS entailments do not change.</li>
-		</ol>
-	  
+		</ol>	  
 		Therefore, we do not impose a well foundedness condition on the definition of IT, 
 	    since this would have no practical consequence for simple, RDF, and RDFS entailments.
 		However, a well foundedness condition may be necessary in extensions of RDF 

--- a/spec/index.html
+++ b/spec/index.html
@@ -1517,7 +1517,7 @@
 
 	<p class="technote"> 
 		The RDFS semantic condition on the triple term mapping IT induces 
-		unwanted <i>non-well founded models</i> for propositions.		
+		potentially unwanted <i>non-well founded models</i> for propositions.		
 		For example, the asserted triple 		
 		&lt;&lt;( :a :b :c )&gt;&gt; :p :o.	  
 		is satisfied in the interpretation where IT maps the denotation of the triple term &lt;x,y,z&gt; 


### PR DESCRIPTION
Added a technical note discussing why non-well founded interpretations are harmless in RDF


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/168.html" title="Last updated on Dec 18, 2025, 9:15 AM UTC (1f4793e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/168/294ddeb...1f4793e.html" title="Last updated on Dec 18, 2025, 9:15 AM UTC (1f4793e)">Diff</a>