### PR TITLE
Make references to RDF Schema non-normative

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -103,7 +103,7 @@
 <section id='abstract'>
   <p>  This document describes a precise semantics for
     [[[RDF12-CONCEPTS]]] [[RDF12-CONCEPTS]]
-    and [[[RDF12-SCHEMA]]] [[RDF12-SCHEMA]].
+    and [[[RDF12-SCHEMA]]] [[?RDF12-SCHEMA]].
     It defines a number of distinct entailment regimes and corresponding patterns of entailment.
     It is part of a suite of documents which comprise the full specification of RDF 1.2.</p>
 </section>
@@ -1243,7 +1243,7 @@
 <section id="rdfs_interpretations">
   <h2>RDFS Interpretations</h2>
 
-  <p>RDF Schema [[RDF12-SCHEMA]]
+  <p>RDF Schema [[?RDF12-SCHEMA]]
     extends RDF to a larger vocabulary
     with more complex semantic constraints:</p>
 


### PR DESCRIPTION
As per WG decision of 20 November 2025.

Fixes #163

<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/169.html" title="Last updated on Nov 20, 2025, 6:05 PM UTC (571ea15)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/169/294ddeb...571ea15.html" title="Last updated on Nov 20, 2025, 6:05 PM UTC (571ea15)">Diff</a>