### PR TITLE
Add id to dataset and dataset merge definitions

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1658,7 +1658,7 @@
     between datasets would require RDF graph entailments between the graphs with the same <a>name</a>
     (adding in empty graphs as required).</p>
 
-  <table id="dfn-rdf-dataset">
+  <table>
     <caption>Definition of an RDF dataset</caption>
     <tr>
        <td class="semantictable">


### PR DESCRIPTION
In the SPARQL Update spec, we need to reference the RDF dataset merge definition. This PR adds an id for this definition, so we can properly reference it.

(requested reviews from the editors of both the RDF 1.2 Semantics and SPARQL 1.2 Update specs)

Closes https://github.com/w3c/sparql-update/issues/51


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/171.html" title="Last updated on Jan 13, 2026, 11:13 AM UTC (40ed9d6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/171/dc661da...40ed9d6.html" title="Last updated on Jan 13, 2026, 11:13 AM UTC (40ed9d6)">Diff</a>