### PR TITLE
add several elements of RDF vocabulary

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1043,7 +1043,7 @@
       <tr>
         <td ><code>rdf:type rdf:reifies rdf:subject rdf:predicate rdf:object
           rdf:first rdf:rest rdf:value rdf:nil
-          rdf:List rdf:langString rdf:dirLangString rdf:Property rdf:_1 rdf:_2
+          rdf:List rdf:langString rdf:dirLangString rdf:Property rdf:Statement rdf:Alt rdf:Bag rdf:Seq rdf:_1 rdf:_2
            ...</code></td>
       </tr>
     </tbody>


### PR DESCRIPTION
Fixes #184


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/186.html" title="Last updated on Feb 19, 2026, 5:25 PM UTC (935a94a)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/186/4a7c939...935a94a.html" title="Last updated on Feb 19, 2026, 5:25 PM UTC (935a94a)">Diff</a>