### PR TITLE
adds missing entailment rule for RDFS

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1604,6 +1604,11 @@
             <td class="othertable">ttt [&lt;&lt;(aaa bbb ccc)>>/_:nnn]<br/>
             _:nnn <code>rdf:type rdfs:Proposition .</code></td>
           </tr>
+          <tr >
+            <td class="othertable"><dfn>rdfs14a</dfn></td>
+            <td class="othertable">(for every S, even empty)</td>
+            <td class="othertable">_:nnn <code>rdf:type rdfs:Proposition .</code></td>
+          </tr>
         </tbody>
       </table>
       <p>As an example of a RDFS entailment involving triple terms using the entailment pattern rdfs14,


### PR DESCRIPTION
it is always true that a proposition exists in the domain. fix #185

Contrarily to the suggestion in #185, I didn't leave the premise cell empty, because it looked more like an error than an ever-true condition.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/187.html" title="Last updated on Mar 20, 2026, 4:59 PM UTC (02965fb)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/187/8b582ee...02965fb.html" title="Last updated on Mar 20, 2026, 4:59 PM UTC (02965fb)">Diff</a>