### PR TITLE
add orcid ids for editors

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -32,13 +32,13 @@
       prevRecShortname:     "rdf11-mt",
 
       editors: [
-        { name: "Peter Patel-Schneider", w3cid: "13382"},
-        { name: "Dörthe Arndt", w3cid: "111308"},
-        { name: "Enrico Franconi", w3cid: "35616"},
+          { name: "Peter Patel-Schneider", w3cid: "13382", orcid: "0009-0000-7789-7459" },
+          { name: "Dörthe Arndt", w3cid: "111308", orcid: "0000-0002-7401-8487" },
+          { name: "Enrico Franconi", w3cid: "35616", orcid: "0000-0002-7814-515X" },
       ],
 
       formerEditors:  [
-        { name: "Patrick J. Hayes" },
+          { name: "Patrick J. Hayes", orcid: "0000-0002-6639-9187" },
       ],
 
       github: "https://github.com/w3c/rdf-semantics/",


### PR DESCRIPTION
Fixes #191


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/192.html" title="Last updated on Apr 2, 2026, 5:46 PM UTC (1713414)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/192/ea1a6d6...1713414.html" title="Last updated on Apr 2, 2026, 5:46 PM UTC (1713414)">Diff</a>