### PR TITLE
Fix link to "substitution mapping"

### DIFF
--- a/spec/index.html
+++ b/spec/index.html
@@ -1140,7 +1140,7 @@
     <section id="rdf_entailment_patterns" class="informative">
       <h4>Patterns of RDF entailment</h4>
 
-      <p>In this Section we make use of the <a data-cite="RDF12-CONCEPTS#dfn-substitution-mapping">substitution mapping</a> notation.</p>
+      <p>In this Section we make use of the <a>substitution mapping</a> notation.</p>
 		
       <p>The last semantic condition in the above table gives the following entailment pattern for <a>recognized</a> datatype IRIs:</p>
 


### PR DESCRIPTION
The notation is now defined in the spec itself.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/pull/200.html" title="Last updated on Aug 25, 2026, 10:41 AM UTC (dcf53a6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/rdf-semantics/200/8aa3ebe...dcf53a6.html" title="Last updated on Aug 25, 2026, 10:41 AM UTC (dcf53a6)">Diff</a>